### PR TITLE
Pretty format

### DIFF
--- a/__tests__/archive.test.js
+++ b/__tests__/archive.test.js
@@ -1,0 +1,295 @@
+import { formatMessageToWikitext, formatMessageWithContext } from '../archive.js';
+
+describe('Message Formatting', () => {
+  const authors = [
+    { memberId: '123', wikiAccount: 'Ironwestie', displayName: 'Ironwestie' },
+    { memberId: '456', wikiAccount: 'TestUser', displayName: 'Test User' }
+  ];
+
+  describe('Basic Message Formatting', () => {
+    test('Simple message with verified author', () => {
+      const message = {
+        content: 'Hello world!',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageToWikitext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=Hello world!}}'
+      );
+    });
+
+    test('Message with unverified author', () => {
+      const message = {
+        content: 'Hello world!',
+        author: { id: '789', username: 'UnknownUser' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageToWikitext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=UnknownUser|2=Hello world!}}'
+      );
+    });
+
+    test('Empty message', () => {
+      const message = {
+        content: '',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageToWikitext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie}}'
+      );
+    });
+  });
+
+  describe('Message Types', () => {
+    test('Reply message', () => {
+      const message = {
+        content: 'This is a reply',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageToWikitext(message, authors, true)).toBe(
+        '{{DiscordLog2|class=ping reply|t= 21:36|1=Ironwestie|2=This is a reply}}'
+      );
+    });
+
+    test('Forwarded message', () => {
+      const message = {
+        content: 'This is a forwarded message',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageToWikitext(message, authors, false, true)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=\'\'Forwarded:\'\'\n<pre>This is a forwarded message</pre>}}'
+      );
+    });
+
+    test('Reply+Forwarded message', () => {
+      const message = {
+        content: 'This is a reply+forwarded message',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageToWikitext(message, authors, true, true)).toBe(
+        '{{DiscordLog2|class=ping reply|t= 21:36|1=Ironwestie|2=\'\'Forwarded:\'\'\n<pre>This is a reply+forwarded message</pre>}}'
+      );
+    });
+
+    test('Pin message', () => {
+      const message = {
+        content: '',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z',
+        type: 6
+      };
+      expect(formatMessageToWikitext(message, authors)).toBe(
+        '{{DiscordLog2|class=system-message|t2= 21:36|1=Ironwestie|2=pinned \'\'\'a message\'\'\' to this channel. See all \'\'\'pinned messages\'\'\'}}'
+      );
+    });
+  });
+
+  describe('Message Content Types', () => {
+    test('Message with embeds', () => {
+      const message = {
+        content: 'Message with embed',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z',
+        embeds: [
+          {
+            title: 'Embed Title',
+            description: 'Embed Description',
+            url: 'https://example.com'
+          }
+        ]
+      };
+      expect(formatMessageToWikitext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=Message with embed}}'
+      );
+    });
+
+    test('Message with attachments', () => {
+      const message = {
+        content: 'Message with attachment',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z',
+        attachments: [
+          {
+            url: 'https://example.com/image.png'
+          }
+        ]
+      };
+      expect(formatMessageToWikitext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=Message with attachment}}'
+      );
+    });
+  });
+
+  describe('Date Formatting', () => {
+    test('Simple date format (default)', () => {
+      const message = {
+        content: 'Message with simple date',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageToWikitext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=Message with simple date}}'
+      );
+    });
+
+    test('Full date format', () => {
+      const message = {
+        content: 'Message with full date',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageToWikitext(message, authors, false, false, false)).toBe(
+        '{{DiscordLog2|t=Fri, 21 Mar 2025 21:36:27 GMT|1=Ironwestie|2=Message with full date}}'
+      );
+    });
+  });
+
+  describe('Complex Messages', () => {
+    test('Message with multiple features', () => {
+      const message = {
+        content: '**Bold text** with a [link](https://siivagunner.fandom.com/wiki/Katamari_Day)',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z',
+        embeds: [
+          {
+            title: 'Embed Title',
+            description: 'Embed Description'
+          }
+        ],
+        attachments: [
+          {
+            url: 'https://example.com/image.png'
+          }
+        ]
+      };
+      expect(formatMessageToWikitext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=\'\'\'Bold text\'\'\' with a [[Katamari Day|link]]}}'
+      );
+    });
+
+    test('Multi-line message with formatting', () => {
+      const message = {
+        content: 'First line\n\n**Second line**\n\n> Quote\n\n- List item',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageToWikitext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=<poem>First line\n\n\'\'\'Second line\'\'\'\n\n<pre>Quote</pre>\n\n\n* List item</poem>}}'
+      );
+    });
+  });
+
+  describe('Edge Cases', () => {
+    test('Message with special characters in content', () => {
+      const message = {
+        content: 'Message with | and } characters',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageToWikitext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=Message with | and } characters}}'
+      );
+    });
+
+    test('Message with very long content', () => {
+      const message = {
+        content: 'A'.repeat(1000), // Very long message
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      const result = formatMessageToWikitext(message, authors);
+      expect(result).toContain('{{DiscordLog2|t= 21:36|1=Ironwestie|2=');
+      expect(result).toContain('A'.repeat(1000));
+      expect(result).toContain('}}');
+    });
+  });
+
+  describe('Message Context Formatting', () => {
+    test('Reply to normal message', () => {
+      const message = {
+        type: 19,
+        content: 'This is a reply',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z',
+        referenced_message: {
+          content: 'Original message',
+          author: { id: '456' },
+          timestamp: '2025-03-21T21:35:27.000Z'
+        }
+      };
+      expect(formatMessageWithContext(message, authors)).toBe(
+        '{{DiscordLog2|class=ping reply|t= 21:35|1=TestUser|2=Original message}}\n\n' +
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=This is a reply}}'
+      );
+    });
+
+    test('Reply to forwarded message', () => {
+      const message = {
+        type: 19,
+        content: 'This is a reply to a forwarded message',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z',
+        referenced_message: {
+          content: 'Forwarded content',
+          author: { id: '456' },
+          timestamp: '2025-03-21T21:35:27.000Z',
+          message_snapshots: [{
+            message: {
+              content: 'Original forwarded content',
+              timestamp: '2025-03-21T21:35:27.000Z'
+            }
+          }]
+        }
+      };
+      expect(formatMessageWithContext(message, authors)).toBe(
+        '{{DiscordLog2|class=ping reply|t= 21:35|1=TestUser|2=\'\'Forwarded:\'\'\n<pre>Original forwarded content</pre>}}\n\n' +
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=This is a reply to a forwarded message}}'
+      );
+    });
+
+    test('Reply without referenced message', () => {
+      const message = {
+        type: 19,
+        content: 'This is a reply without reference',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageWithContext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=This is a reply without reference}}'
+      );
+    });
+
+    test('Forwarded message', () => {
+      const message = {
+        content: 'Forwarding a message',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z',
+        message_reference: { type: 1 },
+        message_snapshots: [{
+          message: {
+            content: 'Original message being forwarded',
+            timestamp: '2025-03-21T21:35:27.000Z'
+          }
+        }]
+      };
+      expect(formatMessageWithContext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:35|1=Ironwestie|2=\'\'Forwarded:\'\'\n<pre>Original message being forwarded</pre>}}'
+      );
+    });
+
+    test('Normal message', () => {
+      const message = {
+        content: 'This is a normal message',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageWithContext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=This is a normal message}}'
+      );
+    });
+  });
+});

--- a/__tests__/markdown.test.js
+++ b/__tests__/markdown.test.js
@@ -150,42 +150,42 @@ describe('Discord to Wikitext Conversion', () => {
     test('Unordered list with dashes', () => {
       const input = '- Item 1\n- Item 2\n  - Subitem 2.1';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '\n\n* Item 1\n* Item 2\n** Subitem 2.1'
+        '\n<poem>\n* Item 1\n* Item 2\n** Subitem 2.1</poem>'
       );
     });
 
     test('Unordered list with asterisks', () => {
         const input = '* Item 1\n* Item 2\n  * Subitem 2.1';
         expect(convertDiscordToWikitext(input, authors)).toBe(
-          '\n\n* Item 1\n* Item 2\n** Subitem 2.1'
+          '\n<poem>\n* Item 1\n* Item 2\n** Subitem 2.1</poem>'
         );
     });
 
     test('Unordered list with indentations', () => {
       const input = '- List of stuff\n  - and things\n  * and more things';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '\n\n* List of stuff\n** and things\n** and more things'
+        '\n<poem>\n* List of stuff\n** and things\n** and more things</poem>'
       );
     });
 
     test('Unordered list with multiple levels of indentations', () => {
       const input = '* First\n  * indent level 1\n  * indent level 1\n    * indent level 2\n    * indent level 2\n  * indent level 1\n* Second';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '\n\n* First\n** indent level 1\n** indent level 1\n*** indent level 2\n*** indent level 2\n** indent level 1\n* Second'
+        '\n<poem>\n* First\n** indent level 1\n** indent level 1\n*** indent level 2\n*** indent level 2\n** indent level 1\n* Second</poem>'
       );
     });
 
     test('Ordered list', () => {
       const input = '1. First\n2. Second\n  1. Subsecond';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '\n\n# First\n# Second\n## Subsecond'
+        '\n<poem>\n# First\n# Second\n## Subsecond</poem>'
       );
     });
 
     test('Ordered list with multiple levels of indentations', () => {
       const input = '1. First\n  1. Subfirst\n  2. Subsecond\n2. Second\n  1. Subfirst\n  2. Subsecond';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '\n\n# First\n## Subfirst\n## Subsecond\n# Second\n## Subfirst\n## Subsecond'
+        '\n<poem>\n# First\n## Subfirst\n## Subsecond\n# Second\n## Subfirst\n## Subsecond</poem>'
       );
     });
   });
@@ -194,28 +194,28 @@ describe('Discord to Wikitext Conversion', () => {
     test('Single line quote', () => {
       const input = '> This is a quote';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '\n This is a quote'
+        '<pre>This is a quote</pre>'
       );
     });
 
     test('Multi-line quote', () => {
       const input = '> First line\n> Second line';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '\n First line\n Second line'
+        '<poem><pre>First line\nSecond line</pre></poem>'
       );
     });
 
     test('Mix of multiline and single line quotes', () => {
       const input = 'Not Quote\n> Quote\n> More quote\nNot quote\n> quote\nNot quote\n> Multiline quote line\n> Multiline quote line 2\nNot quote';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        'Not Quote\n Quote\n More quote\nNot quote\n quote\nNot quote\n Multiline quote line\n Multiline quote line 2\nNot quote'
+        '<poem>Not Quote\n<pre>Quote\nMore quote</pre>\nNot quote\n<pre>quote</pre>\nNot quote\n<pre>Multiline quote line\nMultiline quote line 2</pre>\nNot quote</poem>'
       );
     });
 
     test('Quote at beginning of message', () => {
       const input = '> Quote at beginning\nNot quote';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '\n Quote at beginning\nNot quote'
+        '<poem><pre>Quote at beginning</pre>\nNot quote</poem>'
       );
     });
 
@@ -241,28 +241,28 @@ describe('Discord to Wikitext Conversion', () => {
     test('Heading with one hash', () => {
       const input = '# Heading';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '\n\n<h2> Heading </h2>'
+        '<poem>\n\n<h2> Heading </h2></poem>'
       );
     });
 
     test('Heading with two hashes', () => {
       const input = '## Heading';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '\n\n<h3> Heading </h3>'
+        '<poem>\n\n<h3> Heading </h3></poem>'
       );
     });
 
     test('Heading with three hashes', () => {
       const input = '### Heading';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '\n\n<h4> Heading </h4>'
+        '<poem>\n\n<h4> Heading </h4></poem>'
       );
     });
 
     test('Heading with four hashes', () => {
       const input = '#### Heading';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '\n\n#### Heading'
+        '<poem>\n\n#### Heading</poem>'
       );
     });
   });
@@ -305,6 +305,17 @@ describe('Discord to Wikitext Conversion', () => {
   });
 
   describe('Full Message Formatting', () => {
+    test('Message with multiple lines', () => {
+      const message = {
+        content: 'First line\nSecond line',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageToWikitext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=<poem>First line\nSecond line</poem>}}'
+      );
+    });
+
     test('Message with masked, no embed template link', () => {
       const message = {
         content: 'Masked, no embed: [Template:Nickelodeon](<https://siivagunner.fandom.com/wiki/Template:Nickelodeon>)',
@@ -312,7 +323,7 @@ describe('Discord to Wikitext Conversion', () => {
         timestamp: '2025-03-21T21:36:27.000Z'
       };
       expect(formatMessageToWikitext(message, authors)).toBe(
-        '*Fri, 21 Mar 2025 21:36:27 GMT: [[User:Ironwestie|Ironwestie]]: Masked, no embed: [[Template:Nickelodeon|Template:Nickelodeon]]'
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=Masked, no embed: [[Template:Nickelodeon|Template:Nickelodeon]]}}'
       );
     });
 
@@ -323,7 +334,7 @@ describe('Discord to Wikitext Conversion', () => {
         timestamp: '2025-03-21T21:37:35.000Z'
       };
       expect(formatMessageToWikitext(message, authors)).toBe(
-        '*Fri, 21 Mar 2025 21:37:35 GMT: [[User:Ironwestie|Ironwestie]]: Masked, no embed: [[:Category:Katamari Damacy|Category:Katamari Damacy]]'
+        '{{DiscordLog2|t= 21:37|1=Ironwestie|2=Masked, no embed: [[:Category:Katamari Damacy|Category:Katamari Damacy]]}}'
       );
     });
 
@@ -334,7 +345,7 @@ describe('Discord to Wikitext Conversion', () => {
         timestamp: '2025-03-21T21:38:42.000Z'
       };
       expect(formatMessageToWikitext(message, authors)).toBe(
-        '*Fri, 21 Mar 2025 21:38:42 GMT: [[User:Ironwestie|Ironwestie]]: Masked, no embed: [[Katamari Day|Katamari Day]]'
+        '{{DiscordLog2|t= 21:38|1=Ironwestie|2=Masked, no embed: [[Katamari Day|Katamari Day]]}}'
       );
     });
 
@@ -348,11 +359,11 @@ describe('Discord to Wikitext Conversion', () => {
         timestamp: '2025-03-21T21:39:50.000Z'
       };
       expect(formatMessageToWikitext(message, authors)).toBe(
-        '*Fri, 21 Mar 2025 21:39:50 GMT: [[User:Ironwestie|Ironwestie]]: ' +
+        '{{DiscordLog2|t= 21:39|1=Ironwestie|2=<poem>' +
         "'''Hello''' [[User:Ironwestie|Ironwestie]]!\n\n\n" +
         '# First item with a [[Katamari Day|link]]\n' +
         "# Second item with ''emphasis''\n\n\n" +
-        ' A quote with <u>underline</u>'
+        '<pre>A quote with <u>underline</u></pre></poem>}}'
       );
     });
   });

--- a/__tests__/markdown.test.js
+++ b/__tests__/markdown.test.js
@@ -219,6 +219,13 @@ describe('Discord to Wikitext Conversion', () => {
       );
     });
 
+    test('Quote with list', () => {
+      const input = '> Quote\n> * Item 1 - some content \n> * Item 2 - some content';
+      expect(convertDiscordToWikitext(input, authors)).toBe(
+        '<poem><pre>Quote\n* Item 1 - some content\n* Item 2 - some content</pre></poem>'
+      );
+    });
+
   });
 
   describe('User Mentions', () => {

--- a/__tests__/markdown.test.js
+++ b/__tests__/markdown.test.js
@@ -312,6 +312,18 @@ describe('Discord to Wikitext Conversion', () => {
   });
 
   describe('Full Message Formatting', () => {
+    test('Pin message', () => {
+      const message = {
+        content: '',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z',
+        type: 6
+      };
+      expect(formatMessageToWikitext(message, authors)).toBe(
+        `{{DiscordLog2|class=system-message|t2= 21:36|1=Ironwestie|2=pinned '''a message''' to this channel. See all '''pinned messages'''}}`
+      );
+    });
+
     test('Message with multiple lines', () => {
       const message = {
         content: 'First line\nSecond line',

--- a/app.js
+++ b/app.js
@@ -170,38 +170,7 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async fun
           .filter(message => !message.author.bot) // Remove bot messages
           .reverse();
         const fileContent = `<templatestyles src="Template:DiscordLog/styles.css"/>\n` + messagesReversed.map(message => {
-          const isReply = message.type === 19;
-          const isForwarded = message.message_reference?.type === 1;
-
-          if (isReply) {
-            // Handle reply message
-            const referencedMessage = message.referenced_message;
-            if (referencedMessage) {
-              if (referencedMessage.message_snapshots && referencedMessage.message_snapshots.length > 0) {
-                // Handle a reply to a forwarded message
-                console.log("REFERENCED MESSAGE:", referencedMessage);
-                const messageSnapshot = referencedMessage.message_snapshots[0].message;
-                messageSnapshot.author = referencedMessage.author;
-                return formatMessageToWikitext(messageSnapshot, authors, true, true) + "\n\n" +
-                       formatMessageToWikitext(message, authors);
-              } else {
-                // Handle reply-only message
-                return formatMessageToWikitext(referencedMessage, authors, true) + "\n\n" +
-                       formatMessageToWikitext(message, authors);
-              }
-            } else {
-              console.error("This reply message has no referenced message:", message);
-              return formatMessageToWikitext(message, authors);
-            }
-          } else if (isForwarded) {
-            // Handle forwarded-only message
-            let messageSnapshot = message.message_snapshots[0].message;
-            messageSnapshot.author = message.author; // message_snapshots don't have author info, so set as the forwarded message's author
-            return formatMessageToWikitext(messageSnapshot, authors, false, true);
-          } else {
-            // handle normal messages
-            return formatMessageToWikitext(message, authors); // normal message
-          }
+          return formatMessageToWikitext(message, authors);
         }).join('\n\n');
 
         // Create a buffer from the content

--- a/app.js
+++ b/app.js
@@ -169,7 +169,7 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async fun
         const messagesReversed = messages
           .filter(message => !message.author.bot) // Remove bot messages
           .reverse();
-        const fileContent = messagesReversed.map(message => {
+        const fileContent = `<templatestyles src="Template:DiscordLog/styles.css"/>\n` + messagesReversed.map(message => {
           return formatMessageToWikitext(message, authors);
         }).join('\n\n');
 

--- a/app.js
+++ b/app.js
@@ -170,6 +170,15 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async fun
           .filter(message => !message.author.bot) // Remove bot messages
           .reverse();
         const fileContent = `<templatestyles src="Template:DiscordLog/styles.css"/>\n` + messagesReversed.map(message => {
+          if (message.type === 19) { // reply message
+            // insert the reply message  here
+            if (message.referenced_message) {
+              return formatMessageToWikitext(message.referenced_message, authors, true) + "\n\n" + formatMessageToWikitext(message, authors);
+            } else {
+              console.log("This reply message has no referenced message:", message);
+              return formatMessageToWikitext(message, authors);
+            }
+          }
           return formatMessageToWikitext(message, authors);
         }).join('\n\n');
 

--- a/app.js
+++ b/app.js
@@ -175,9 +175,13 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async fun
             if (message.referenced_message) {
               return formatMessageToWikitext(message.referenced_message, authors, true) + "\n\n" + formatMessageToWikitext(message, authors);
             } else {
-              console.log("This reply message has no referenced message:", message);
+              console.error("This reply message has no referenced message:", message);
               return formatMessageToWikitext(message, authors);
             }
+          } else if (message.message_reference && message.message_reference.type === 1) { // forwarded message
+            let messageSnapshot = message.message_snapshots[0].message;
+            messageSnapshot.author = message.author; // message_snapshots don't have author info, so set as the forwarded message's author
+            return formatMessageToWikitext(messageSnapshot, authors, false, true);
           }
           return formatMessageToWikitext(message, authors);
         }).join('\n\n');

--- a/app.js
+++ b/app.js
@@ -170,20 +170,38 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async fun
           .filter(message => !message.author.bot) // Remove bot messages
           .reverse();
         const fileContent = `<templatestyles src="Template:DiscordLog/styles.css"/>\n` + messagesReversed.map(message => {
-          if (message.type === 19) { // reply message
-            // insert the reply message  here
-            if (message.referenced_message) {
-              return formatMessageToWikitext(message.referenced_message, authors, true) + "\n\n" + formatMessageToWikitext(message, authors);
+          const isReply = message.type === 19;
+          const isForwarded = message.message_reference?.type === 1;
+
+          if (isReply) {
+            // Handle reply message
+            const referencedMessage = message.referenced_message;
+            if (referencedMessage) {
+              if (referencedMessage.message_snapshots && referencedMessage.message_snapshots.length > 0) {
+                // Handle a reply to a forwarded message
+                console.log("REFERENCED MESSAGE:", referencedMessage);
+                const messageSnapshot = referencedMessage.message_snapshots[0].message;
+                messageSnapshot.author = referencedMessage.author;
+                return formatMessageToWikitext(messageSnapshot, authors, true, true) + "\n\n" +
+                       formatMessageToWikitext(message, authors);
+              } else {
+                // Handle reply-only message
+                return formatMessageToWikitext(referencedMessage, authors, true) + "\n\n" +
+                       formatMessageToWikitext(message, authors);
+              }
             } else {
               console.error("This reply message has no referenced message:", message);
               return formatMessageToWikitext(message, authors);
             }
-          } else if (message.message_reference && message.message_reference.type === 1) { // forwarded message
+          } else if (isForwarded) {
+            // Handle forwarded-only message
             let messageSnapshot = message.message_snapshots[0].message;
             messageSnapshot.author = message.author; // message_snapshots don't have author info, so set as the forwarded message's author
             return formatMessageToWikitext(messageSnapshot, authors, false, true);
+          } else {
+            // handle normal messages
+            return formatMessageToWikitext(message, authors); // normal message
           }
-          return formatMessageToWikitext(message, authors);
         }).join('\n\n');
 
         // Create a buffer from the content

--- a/archive.js
+++ b/archive.js
@@ -20,7 +20,13 @@ export function formatMessageToWikitext (message, authors, simpleDate = true) {
 
     const timestamp = new Date(message.timestamp).toUTCString();
     const timestampFormatted = simpleDate ? timestamp.slice(16, 22) : timestamp;
-    parts.push(`t=${timestampFormatted}`);
+
+    if (message.type === 6) { // Pin message
+      parts.push('class=system-message');
+      parts.push(`t2=${timestampFormatted}`);
+    } else {
+      parts.push(`t=${timestampFormatted}`);
+    }
 
     let authorWikiAccount = authors.find(author => author.memberId === message.author.id)
     if (!authorWikiAccount) {
@@ -34,6 +40,9 @@ export function formatMessageToWikitext (message, authors, simpleDate = true) {
     if (message.content) {
       const wikitextContent = convertDiscordToWikitext(message.content, authors);
       parts.push(`2=${wikitextContent}`);
+    } else if (message.type === 6) { // Pin message
+      // Pin messages have no content, so we need to add the message ourselves
+      parts.push(`2=pinned '''a message''' to this channel. See all '''pinned messages'''`);
     }
 
     // Add embed and attachment content

--- a/archive.js
+++ b/archive.js
@@ -8,10 +8,11 @@ import {
    * Format a message to wikitext
    * @param {*} message The message to format. Format:
    * @param {Array} authors The array of verified members
+   * @param {boolean} reply Whether the message is a reply
    * @param {boolean} simpleDate Whether to use the simple date format (21:56) or the full date format (Fri, 21 Mar 2025 21:56)
    * @returns A string of the message formatted as wikitext
    */
-export function formatMessageToWikitext (message, authors, simpleDate = true) {
+export function formatMessageToWikitext (message, authors, reply = false, simpleDate = true) {
     // Format:
     // {{DiscordLog|t=timestamp|authorLink|content}}
     const templatePrefix = `{{DiscordLog2`
@@ -25,7 +26,10 @@ export function formatMessageToWikitext (message, authors, simpleDate = true) {
       parts.push('class=system-message');
       parts.push(`t2=${timestampFormatted}`);
     } else {
-      parts.push(`t=${timestampFormatted}`);
+        if (reply) { // replies have the class ping-reply
+            parts.push('class=ping-reply');
+        }
+        parts.push(`t=${timestampFormatted}`);
     }
 
     let authorWikiAccount = authors.find(author => author.memberId === message.author.id)

--- a/archive.js
+++ b/archive.js
@@ -32,7 +32,7 @@ export function formatMessageToWikitext (message, authors, reply = false, forwar
       parts.push(`t2=${timestampFormatted}`);
     } else {
         if (reply) { // replies have the class ping-reply
-            parts.push('class=ping-reply');
+            parts.push('class=ping reply');
         }
         parts.push(`t=${timestampFormatted}`);
     }
@@ -74,9 +74,10 @@ export function formatMessageToWikitext (message, authors, reply = false, forwar
       });
     }
 
-    if (embeds.length > 0) {
-        parts.push(`${embeds.join('\n')}`);
-    }
+    // do not render embeds for now
+    // if (embeds.length > 0) {
+    //     parts.push(`${embeds.join('\n')}`);
+    // }
 
     return parts.join('|') + "}}";
   }

--- a/archive.js
+++ b/archive.js
@@ -16,10 +16,6 @@ import {
 export function formatMessageToWikitext (message, authors, reply = false, forwarded = false, simpleDate = true) {
     // Format:
     // {{DiscordLog|t=timestamp|authorLink|content}}
-    if (reply && forwarded) {
-        console.error("This message is both a reply and a forwarded message:", message);
-        return '';
-    }
     const templatePrefix = `{{DiscordLog2`
     const parts = [];
     parts.push(templatePrefix);

--- a/archive.js
+++ b/archive.js
@@ -266,3 +266,43 @@ export async function getMemberInfo(guildId, memberId) {
         throw error;
     }
 }
+
+/**
+ * Format a message with its context (replies and forwards)
+ * @param {Object} message The message to format
+ * @param {Array} authors Array of verified members
+ * @returns {string} The formatted message with context
+ */
+export function formatMessageWithContext(message, authors) {
+  const isReply = message.type === 19;
+  const isForwarded = message.message_reference?.type === 1;
+
+  if (isReply) {
+    // Handle reply message
+    const referencedMessage = message.referenced_message;
+    if (referencedMessage) {
+      if (referencedMessage.message_snapshots && referencedMessage.message_snapshots.length > 0) {
+        // Handle a reply to a forwarded message
+        const messageSnapshot = referencedMessage.message_snapshots[0].message;
+        messageSnapshot.author = referencedMessage.author;
+        return formatMessageToWikitext(messageSnapshot, authors, true, true) + "\n\n" +
+               formatMessageToWikitext(message, authors);
+      } else {
+        // Handle reply-only message
+        return formatMessageToWikitext(referencedMessage, authors, true) + "\n\n" +
+               formatMessageToWikitext(message, authors);
+      }
+    } else {
+      console.error("This reply message has no referenced message:", message);
+      return formatMessageToWikitext(message, authors);
+    }
+  } else if (isForwarded) {
+    // Handle forwarded-only message
+    let messageSnapshot = message.message_snapshots[0].message;
+    messageSnapshot.author = message.author; // message_snapshots don't have author info, so set as the forwarded message's author
+    return formatMessageToWikitext(messageSnapshot, authors, false, true);
+  } else {
+    // handle normal messages
+    return formatMessageToWikitext(message, authors); // normal message
+  }
+}

--- a/archive.js
+++ b/archive.js
@@ -9,12 +9,17 @@ import {
    * @param {*} message The message to format. Format:
    * @param {Array} authors The array of verified members
    * @param {boolean} reply Whether the message is a reply
+   * @param {boolean} forwarded Whether the message is a forwarded message
    * @param {boolean} simpleDate Whether to use the simple date format (21:56) or the full date format (Fri, 21 Mar 2025 21:56)
    * @returns A string of the message formatted as wikitext
    */
-export function formatMessageToWikitext (message, authors, reply = false, simpleDate = true) {
+export function formatMessageToWikitext (message, authors, reply = false, forwarded = false, simpleDate = true) {
     // Format:
     // {{DiscordLog|t=timestamp|authorLink|content}}
+    if (reply && forwarded) {
+        console.error("This message is both a reply and a forwarded message:", message);
+        return '';
+    }
     const templatePrefix = `{{DiscordLog2`
     const parts = [];
     parts.push(templatePrefix);
@@ -42,8 +47,12 @@ export function formatMessageToWikitext (message, authors, reply = false, simple
     parts.push(`1=${authorWikiAccount}`);
 
     if (message.content) {
-      const wikitextContent = convertDiscordToWikitext(message.content, authors);
-      parts.push(`2=${wikitextContent}`);
+      const wikitextContent = convertDiscordToWikitext(message.content, authors, forwarded);
+      if (forwarded) {
+        parts.push(`2=''Forwarded:''\n${wikitextContent}`);
+      } else {
+        parts.push(`2=${wikitextContent}`);
+      }
     } else if (message.type === 6) { // Pin message
       // Pin messages have no content, so we need to add the message ourselves
       parts.push(`2=pinned '''a message''' to this channel. See all '''pinned messages'''`);

--- a/markdown.js
+++ b/markdown.js
@@ -347,12 +347,11 @@ export const renderContent = (content, { containsList, containsQuotes } = {}) =>
  * Convert Discord-formatted text to wikitext
  * @param {string} content The Discord-formatted text to convert
  * @param {Array} authors Array of verified members for @mention conversion
+ * @param {boolean} forwarded Whether the message is a forwarded message
  * @returns {string} The converted wikitext
  */
-export const convertDiscordToWikitext = (content, authors = []) => {
+export const convertDiscordToWikitext = (content, authors = [], forwarded = false) => {
   const startsWithList = contentStartsWith.list(content);
-  const startsWithQuote = contentStartsWith.quote(content);
-
   // First process templates and links
   content = processTemplates(content);
   content = processLinks(content);
@@ -453,8 +452,9 @@ export const convertDiscordToWikitext = (content, authors = []) => {
       return `[[${pageName.replace(/_/g, ' ')}]]`;
     });
 
-  // if content has multiple lines, surround it with <poem> tags
-  if (content.split('\n').length > 1) {
+  if (forwarded) {
+    content = `<pre>${content}</pre>`;
+  } else if (content.split('\n').length > 1) {   // if content has multiple lines, <pre> tags are necessary for rendering
     content = `<poem>${content}</poem>`;
   }
 

--- a/markdown.js
+++ b/markdown.js
@@ -400,6 +400,10 @@ export const convertDiscordToWikitext = (content, authors = []) => {
       // If next line is not a quote, process the block
       if (!isNextQuote) {
         const renderedContent = quoteBlock.map(quote => {
+          // Don't process markdown for list items in quotes
+          if (quote.trim().startsWith('* ')) {
+            return quote.trim();
+          }
           return md.render(quote)
             .replace(/<\/?p>/g, '')
             .replace(/\n$/, '');

--- a/markdown.js
+++ b/markdown.js
@@ -370,7 +370,8 @@ export const convertDiscordToWikitext = (content, authors = []) => {
     })
     .replace(/<#(\d+)>/g, '#$1')
     .replace(/<@&(\d+)>/g, '@$1')
-    .replace(/<:([^:]+):(\d+)>/g, ':$1:');
+    .replace(/<:([^:]+):(\d+)>/g, ':$1:')
+    .replace(/(\=\=\=)/g, '<nowiki>$1</nowiki>');
 
   // Process voting emojis
   content = processVotingEmojis(content);
@@ -435,6 +436,11 @@ export const convertDiscordToWikitext = (content, authors = []) => {
     .replace(/https:\/\/siivagunner\.fandom\.com\/wiki\/([^\s\]]+)/g, (match, pageName) => {
       return `[[${pageName.replace(/_/g, ' ')}]]`;
     });
+
+  // if content has multiple lines, surround it with <poem> tags
+  if (content.split('\n').length > 1) {
+    content = `<poem>${content}</poem>`;
+  }
 
   return startsWithList || startsWithQuote ? '\n' + content : content;
 };


### PR DESCRIPTION
Resolves #14.

Logs now use [Template:DiscordLog](https://siivagunner.fandom.com/wiki/Template:DiscordLog), which supports formatting for:
- Replies (resolves #18)
- Forwarded messages (resolves #19)
- System messages, specifically "pinned" notification messages (resolves #20)

Embeds have been disabled for now. They aren't supported at present, and they make pages cluttered.

I will implement #22 in a future PR.