### PR TITLE
Formatting fixes

### DIFF
--- a/__tests__/archive.test.js
+++ b/__tests__/archive.test.js
@@ -60,7 +60,7 @@ describe('Message Formatting', () => {
         timestamp: '2025-03-21T21:36:27.000Z'
       };
       expect(formatMessageToWikitext(message, authors, false, true)).toBe(
-        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=\'\'Forwarded:\'\'\n<pre>This is a forwarded message</pre>}}'
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=\'\'Forwarded:\'\'\n<blockquote>This is a forwarded message</blockquote>}}'
       );
     });
 
@@ -71,7 +71,7 @@ describe('Message Formatting', () => {
         timestamp: '2025-03-21T21:36:27.000Z'
       };
       expect(formatMessageToWikitext(message, authors, true, true)).toBe(
-        '{{DiscordLog2|class=ping reply|1=Ironwestie|2=\'\'Forwarded:\'\'\n<pre>This is a reply+forwarded message</pre>}}'
+        '{{DiscordLog2|class=ping reply|1=Ironwestie|2=\'\'Forwarded:\'\'\n<blockquote>This is a reply+forwarded message</blockquote>}}'
       );
     });
 
@@ -178,7 +178,7 @@ describe('Message Formatting', () => {
         timestamp: '2025-03-21T21:36:27.000Z'
       };
       expect(formatMessageToWikitext(message, authors)).toBe(
-        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=First line\n\'\'\'Second line\'\'\'\n<pre>Quote</pre>\n* List item}}'
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=First line\n\'\'\'Second line\'\'\'\n<blockquote>Quote</blockquote>\n* List item}}'
       );
     });
   });
@@ -246,7 +246,7 @@ describe('Message Formatting', () => {
         }
       };
       expect(formatMessageWithContext(message, authors)).toBe(
-        '{{DiscordLog2|class=ping reply|1=TestUser|2=\'\'Forwarded:\'\'\n<pre>Original forwarded content</pre>}}\n' +
+        '{{DiscordLog2|class=ping reply|1=TestUser|2=\'\'Forwarded:\'\'\n<blockquote>Original forwarded content</blockquote>}}\n' +
         '{{DiscordLog2|t= 21:36|1=Ironwestie|2=This is a reply to a forwarded message}}'
       );
     });
@@ -277,7 +277,7 @@ describe('Message Formatting', () => {
         }]
       };
       expect(formatMessageWithContext(message, authors)).toBe(
-        '{{DiscordLog2|t= 21:35|1=Ironwestie|2=\'\'Forwarded:\'\'\n<pre>Original message being forwarded</pre>}}'
+        '{{DiscordLog2|t= 21:35|1=Ironwestie|2=\'\'Forwarded:\'\'\n<blockquote>Original message being forwarded</blockquote>}}'
       );
     });
 

--- a/__tests__/archive.test.js
+++ b/__tests__/archive.test.js
@@ -49,7 +49,7 @@ describe('Message Formatting', () => {
         timestamp: '2025-03-21T21:36:27.000Z'
       };
       expect(formatMessageToWikitext(message, authors, true)).toBe(
-        '{{DiscordLog2|class=ping reply|t= 21:36|1=Ironwestie|2=This is a reply}}'
+        '{{DiscordLog2|class=ping reply|1=Ironwestie|2=This is a reply}}'
       );
     });
 
@@ -71,7 +71,7 @@ describe('Message Formatting', () => {
         timestamp: '2025-03-21T21:36:27.000Z'
       };
       expect(formatMessageToWikitext(message, authors, true, true)).toBe(
-        '{{DiscordLog2|class=ping reply|t= 21:36|1=Ironwestie|2=\'\'Forwarded:\'\'\n<pre>This is a reply+forwarded message</pre>}}'
+        '{{DiscordLog2|class=ping reply|1=Ironwestie|2=\'\'Forwarded:\'\'\n<pre>This is a reply+forwarded message</pre>}}'
       );
     });
 
@@ -222,7 +222,7 @@ describe('Message Formatting', () => {
         }
       };
       expect(formatMessageWithContext(message, authors)).toBe(
-        '{{DiscordLog2|class=ping reply|t= 21:35|1=TestUser|2=Original message}}\n' +
+        '{{DiscordLog2|class=ping reply|1=TestUser|2=Original message}}\n' +
         '{{DiscordLog2|t= 21:36|1=Ironwestie|2=This is a reply}}'
       );
     });
@@ -246,7 +246,7 @@ describe('Message Formatting', () => {
         }
       };
       expect(formatMessageWithContext(message, authors)).toBe(
-        '{{DiscordLog2|class=ping reply|t= 21:35|1=TestUser|2=\'\'Forwarded:\'\'\n<pre>Original forwarded content</pre>}}\n' +
+        '{{DiscordLog2|class=ping reply|1=TestUser|2=\'\'Forwarded:\'\'\n<pre>Original forwarded content</pre>}}\n' +
         '{{DiscordLog2|t= 21:36|1=Ironwestie|2=This is a reply to a forwarded message}}'
       );
     });

--- a/__tests__/archive.test.js
+++ b/__tests__/archive.test.js
@@ -178,7 +178,7 @@ describe('Message Formatting', () => {
         timestamp: '2025-03-21T21:36:27.000Z'
       };
       expect(formatMessageToWikitext(message, authors)).toBe(
-        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=<poem>First line\n\'\'\'Second line\'\'\'\n<pre>Quote</pre>\n* List item</poem>}}'
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=First line\n\'\'\'Second line\'\'\'\n<pre>Quote</pre>\n* List item}}'
       );
     });
   });

--- a/__tests__/markdown.test.js
+++ b/__tests__/markdown.test.js
@@ -194,35 +194,35 @@ describe('Discord to Wikitext Conversion', () => {
     test('Single line quote', () => {
       const input = '> This is a quote';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<pre>This is a quote</pre>'
+        '<blockquote>This is a quote</blockquote>'
       );
     });
 
     test('Multi-line quote', () => {
       const input = '> First line\n> Second line';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<pre>First line\nSecond line</pre>'
+        '<blockquote>First line\nSecond line</blockquote>'
       );
     });
 
     test('Mix of multiline and single line quotes', () => {
       const input = 'Not Quote\n> Quote\n> More quote\nNot quote\n> quote\nNot quote\n> Multiline quote line\n> Multiline quote line 2\nNot quote';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        'Not Quote\n<pre>Quote\nMore quote</pre>\nNot quote\n<pre>quote</pre>\nNot quote\n<pre>Multiline quote line\nMultiline quote line 2</pre>\nNot quote'
+        'Not Quote\n<blockquote>Quote\nMore quote</blockquote>\nNot quote\n<blockquote>quote</blockquote>\nNot quote\n<blockquote>Multiline quote line\nMultiline quote line 2</blockquote>\nNot quote'
       );
     });
 
     test('Quote at beginning of message', () => {
       const input = '> Quote at beginning\nNot quote';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<pre>Quote at beginning</pre>\nNot quote'
+        '<blockquote>Quote at beginning</blockquote>\nNot quote'
       );
     });
 
     test('Quote with list', () => {
       const input = '> Quote\n> * Item 1 - some content \n> * Item 2 - some content';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<pre>Quote\n* Item 1 - some content\n* Item 2 - some content</pre>'
+        '<blockquote>Quote\n* Item 1 - some content\n* Item 2 - some content</blockquote>'
       );
     });
 
@@ -319,7 +319,7 @@ describe('Discord to Wikitext Conversion', () => {
         timestamp: '2025-03-21T21:36:27.000Z'
       };
       expect(formatMessageToWikitext(message, authors)).toBe(
-        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=<pre>Quote</pre>}}'
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=<blockquote>Quote</blockquote>}}'
       );
     });
     test('Pin message', () => {
@@ -392,7 +392,7 @@ describe('Discord to Wikitext Conversion', () => {
         "'''Hello''' [[User:Ironwestie|Ironwestie]]!\n" +
         '# First item with a [[Katamari Day|link]]\n' +
         "# Second item with ''emphasis''\n" +
-        '<pre>A quote with <u>underline</u></pre>}}'
+        '<blockquote>A quote with <u>underline</u></blockquote>}}'
       );
     });
   });

--- a/__tests__/markdown.test.js
+++ b/__tests__/markdown.test.js
@@ -150,42 +150,42 @@ describe('Discord to Wikitext Conversion', () => {
     test('Unordered list with dashes', () => {
       const input = '- Item 1\n- Item 2\n  - Subitem 2.1';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<poem>\n* Item 1\n* Item 2\n** Subitem 2.1</poem>'
+        '\n* Item 1\n* Item 2\n** Subitem 2.1'
       );
     });
 
     test('Unordered list with asterisks', () => {
         const input = '* Item 1\n* Item 2\n  * Subitem 2.1';
         expect(convertDiscordToWikitext(input, authors)).toBe(
-          '<poem>\n* Item 1\n* Item 2\n** Subitem 2.1</poem>'
+          '\n* Item 1\n* Item 2\n** Subitem 2.1'
         );
     });
 
     test('Unordered list with indentations', () => {
       const input = '- List of stuff\n  - and things\n  * and more things';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<poem>\n* List of stuff\n** and things\n** and more things</poem>'
+        '\n* List of stuff\n** and things\n** and more things'
       );
     });
 
     test('Unordered list with multiple levels of indentations', () => {
       const input = '* First\n  * indent level 1\n  * indent level 1\n    * indent level 2\n    * indent level 2\n  * indent level 1\n* Second';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<poem>\n* First\n** indent level 1\n** indent level 1\n*** indent level 2\n*** indent level 2\n** indent level 1\n* Second</poem>'
+        '\n* First\n** indent level 1\n** indent level 1\n*** indent level 2\n*** indent level 2\n** indent level 1\n* Second'
       );
     });
 
     test('Ordered list', () => {
       const input = '1. First\n2. Second\n  1. Subsecond';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<poem>\n# First\n# Second\n## Subsecond</poem>'
+        '\n# First\n# Second\n## Subsecond'
       );
     });
 
     test('Ordered list with multiple levels of indentations', () => {
       const input = '1. First\n  1. Subfirst\n  2. Subsecond\n2. Second\n  1. Subfirst\n  2. Subsecond';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<poem>\n# First\n## Subfirst\n## Subsecond\n# Second\n## Subfirst\n## Subsecond</poem>'
+        '\n# First\n## Subfirst\n## Subsecond\n# Second\n## Subfirst\n## Subsecond'
       );
     });
   });
@@ -201,28 +201,28 @@ describe('Discord to Wikitext Conversion', () => {
     test('Multi-line quote', () => {
       const input = '> First line\n> Second line';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<poem><pre>First line\nSecond line</pre></poem>'
+        '<pre>First line\nSecond line</pre>'
       );
     });
 
     test('Mix of multiline and single line quotes', () => {
       const input = 'Not Quote\n> Quote\n> More quote\nNot quote\n> quote\nNot quote\n> Multiline quote line\n> Multiline quote line 2\nNot quote';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<poem>Not Quote\n<pre>Quote\nMore quote</pre>\nNot quote\n<pre>quote</pre>\nNot quote\n<pre>Multiline quote line\nMultiline quote line 2</pre>\nNot quote</poem>'
+        'Not Quote\n<pre>Quote\nMore quote</pre>\nNot quote\n<pre>quote</pre>\nNot quote\n<pre>Multiline quote line\nMultiline quote line 2</pre>\nNot quote'
       );
     });
 
     test('Quote at beginning of message', () => {
       const input = '> Quote at beginning\nNot quote';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<poem><pre>Quote at beginning</pre>\nNot quote</poem>'
+        '<pre>Quote at beginning</pre>\nNot quote'
       );
     });
 
     test('Quote with list', () => {
       const input = '> Quote\n> * Item 1 - some content \n> * Item 2 - some content';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<poem><pre>Quote\n* Item 1 - some content\n* Item 2 - some content</pre></poem>'
+        '<pre>Quote\n* Item 1 - some content\n* Item 2 - some content</pre>'
       );
     });
 
@@ -341,7 +341,7 @@ describe('Discord to Wikitext Conversion', () => {
         timestamp: '2025-03-21T21:36:27.000Z'
       };
       expect(formatMessageToWikitext(message, authors)).toBe(
-        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=<poem>First line\nSecond line</poem>}}'
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=First line\nSecond line}}'
       );
     });
 
@@ -388,11 +388,11 @@ describe('Discord to Wikitext Conversion', () => {
         timestamp: '2025-03-21T21:39:50.000Z'
       };
       expect(formatMessageToWikitext(message, authors)).toBe(
-        '{{DiscordLog2|t= 21:39|1=Ironwestie|2=<poem>' +
+        '{{DiscordLog2|t= 21:39|1=Ironwestie|2=' +
         "'''Hello''' [[User:Ironwestie|Ironwestie]]!\n" +
         '# First item with a [[Katamari Day|link]]\n' +
         "# Second item with ''emphasis''\n" +
-        '<pre>A quote with <u>underline</u></pre></poem>}}'
+        '<pre>A quote with <u>underline</u></pre>}}'
       );
     });
   });

--- a/__tests__/markdown.test.js
+++ b/__tests__/markdown.test.js
@@ -248,21 +248,21 @@ describe('Discord to Wikitext Conversion', () => {
     test('Heading with one hash', () => {
       const input = '# Heading';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<h2> Heading </h2>'
+        '{{Fake heading|h2|Heading}}'
       );
     });
 
     test('Heading with two hashes', () => {
       const input = '## Heading';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<h3> Heading </h3>'
+        '{{Fake heading|h3|Heading}}'
       );
     });
 
     test('Heading with three hashes', () => {
       const input = '### Heading';
       expect(convertDiscordToWikitext(input, authors)).toBe(
-        '<h4> Heading </h4>'
+        '{{Fake heading|h4|Heading}}'
       );
     });
 

--- a/archive.js
+++ b/archive.js
@@ -26,11 +26,10 @@ export function formatMessageToWikitext (message, authors, reply = false, forwar
     if (message.type === 6) { // Pin message
       parts.push('class=system-message');
       parts.push(`t2=${timestampFormatted}`);
+    } else if (reply) { // replies have the class ping-reply and do not have a timestamp
+      parts.push('class=ping reply');
     } else {
-        if (reply) { // replies have the class ping-reply
-            parts.push('class=ping reply');
-        }
-        parts.push(`t=${timestampFormatted}`);
+      parts.push(`t=${timestampFormatted}`);
     }
 
     let authorWikiAccount = authors.find(author => author.memberId === message.author.id)

--- a/markdown.js
+++ b/markdown.js
@@ -443,11 +443,8 @@ export const convertDiscordToWikitext = (content, authors = [], forwarded = fals
 
   if (forwarded) {
     content = `<pre>${content}</pre>`;
-  } else if (content.split('\n').length > 1 || startsWithList) {   // if content has multiple lines, lists, or headings, <poem> tags are necessary for rendering
-    if (startsWithList) {
-      content = '\n' + content;
-    }
-    content = `<poem>${content}</poem>`;
+  } else if (startsWithList) {
+    content = '\n' + content;
   }
 
   return content;

--- a/markdown.js
+++ b/markdown.js
@@ -285,7 +285,7 @@ export const processHeadings = (content) => {
     // Add 1 to header level since Discord's # is h2 (h1 is reserved for page titles)
     const level = Math.min(6, hashes.length + 1);
     // Add spaces around text
-    return `<h${level}> ${text} </h${level}>`;
+    return `{{Fake heading|h${level}|${text}}}`;
   });
 };
 

--- a/markdown.js
+++ b/markdown.js
@@ -14,8 +14,8 @@ md.renderer.rules.strong_close = () => "'''";
 md.renderer.rules.em_open = () => "''";
 md.renderer.rules.em_close = () => "''";
 md.renderer.rules.code_inline = (tokens, idx) => `<code>${tokens[idx].content}</code>`;
-md.renderer.rules.fence = (tokens, idx) => `<pre>${tokens[idx].content}</pre>`;
-md.renderer.rules.code_block = (tokens, idx) => `<pre>${tokens[idx].content}</pre>`;
+md.renderer.rules.fence = (tokens, idx) => `<blockquote>${tokens[idx].content}</blockquote>`;
+md.renderer.rules.code_block = (tokens, idx) => `<blockquote>${tokens[idx].content}</blockquote>`;
 
 // List rendering rules for MediaWiki format
 md.renderer.rules.bullet_list_open = () => '';
@@ -290,7 +290,7 @@ export const processHeadings = (content) => {
 };
 
 export const processQuotes = (content) => {
-  return content.replace(/^>\s*(.+)$/gm, '<pre>$1</pre>');
+  return content.replace(/^>\s*(.+)$/gm, '<blockquote>$1</blockquote>');
 };
 
 export const processVotingEmojis = (content) => {
@@ -405,7 +405,7 @@ export const convertDiscordToWikitext = (content, authors = [], forwarded = fals
             .replace(/<\/?p>/g, '')
             .replace(/\n$/, '');
         }).join('\n');
-        processedLines.push(`<pre>${renderedContent}</pre>`);
+        processedLines.push(`<blockquote>${renderedContent}</blockquote>`);
         quoteBlock = [];
       }
     } else if (unorderedMatch || orderedMatch) {
@@ -442,7 +442,7 @@ export const convertDiscordToWikitext = (content, authors = [], forwarded = fals
     });
 
   if (forwarded) {
-    content = `<pre>${content}</pre>`;
+    content = `<blockquote>${content}</blockquote>`;
   } else if (startsWithList) {
     content = '\n' + content;
   }


### PR DESCRIPTION
Fixes several issues:

- <poem> tags are no longer needed for multi-line messages, so they have been removed
- replies in Discord do not include timestamps, so they have been excluded
- < pre> tags are primarily for multi-line blocks of code, not for quotes. Quotes now use < blockquote> tags instead.
- Real headings introduce formatting issues, so heading tags (e.g. < h2>) have been replaced with [Template:Fake heading](<https://siivagunner.fandom.com/wiki/Template:Fake_heading>).