### PR TITLE
feat: automate meme proposal closing (/close + wiki + tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,43 +2,98 @@
 
 ## Overview
 
-DiscordWikitextArchive is a Discord bot designed to archive specific discussion threads and convert them into MediaWiki-compatible wikitext. It streamlines the process of logging Discord discussions for use on wikis, making it fast, intuitive, and privacy-conscious.
+DiscordWikitextArchive is a Discord bot designed to archive specific discussion threads, convert them into MediaWiki-compatible wikitext, and automate the mechanical parts of closing meme proposals. It streamlines the process of logging Discord discussions for use on wikis, making it fast, intuitive, and privacy-conscious.
+
 ![Discord original](https://github.com/user-attachments/assets/eb03f742-7c46-477b-8c55-2c38640a039a)
 
 ![Discord Wikitext Archive](https://github.com/user-attachments/assets/c084c5c7-de55-4920-b7f4-17edbe1ab37f)
+
 ## Features
 
-- **Command-Based Functionality**: Use the `/archive` command to format Discord markdown into MediaWiki wikitext. Supported features include:
-    - Basic formatting (e.g., italics, quotes, underlining).
+- **Thread Archiving** (`/archive`): Converts Discord thread messages into MediaWiki wikitext, including:
+    - Basic formatting (italics, bold, quotes, underlining, spoilers, code blocks).
     - Replies and forwarded messages.
-- **Privacy Controls**: Restricts commands to authorized users and specific channels to ensure discussions are logged securely.
-- **Participant Mapping**: Maps verified discussion participants from Discord accounts to their corresponding wiki accounts for accountability.
-
+    - Voting emoji conversion.
+- **Proposal Closing** (`/close`): Automates the full workflow of closing a meme proposal:
+    - Best-effort vote counting with strikethrough crossout detection.
+    - Threshold evaluation (75% majority, 7 voter minimum).
+    - Preview of all planned changes with confirm/cancel buttons.
+    - Discord thread management (rename with `[CLOSED]`, lock).
+    - Wiki page edits via MediaWiki API: create log page, update archive, update proposals page, scaffold to-do and progress entries.
+- **Privacy Controls**: Restricts commands to authorized roles and specific channels.
+- **Participant Mapping**: Maps verified Discord members to their wiki accounts via `/verified_members`.
 
 ## Impact
 
 - Serves a **300+ member Discord server**, facilitating over **30 monthly text discussions**.
 - Reduces logging time from **1 hour to just 10 seconds**, significantly improving efficiency.
+- Automates **5+ wiki page edits** per proposal close, previously done manually.
 
 ## Motivation
 
 This project was born out of a need to streamline the logging process for a popular music-related wiki with over 50 active editors. Regular decision-making discussions on Discord often required manual transcription into wikitext, which was time-consuming (30 minutes to 1 hour). The bot provides a simple solution that allows even non-technical moderators to log discussions in seconds using a single command.
 
-## Development Insights
+## Environment Variables
 
-- **Tooling**: Development was accelerated using Cursor, cutting development time in half.
-- **Lessons Learned**:
-    - Importance of testing and gathering feedback from non-technical users.
-    - Effective organization of projects for ease of use and scalability.
+| Variable | Description |
+|---|---|
+| `APP_ID` | Discord application ID |
+| `DISCORD_TOKEN` | Discord bot token |
+| `PUBLIC_KEY` | Discord public key for interaction verification |
+| `GUILD_ID` | Discord server (guild) ID |
+| `WIKI_API_URL` | MediaWiki API endpoint (e.g. `https://siivagunner.wiki/w/api.php`) |
+| `WIKI_USERNAME` | MediaWiki bot account username |
+| `WIKI_PASSWORD` | MediaWiki bot password |
 
-## Future Plans
+## Commands
 
-- Explore additional Discord bot scripts to automate administrative processes on the wiki (pending community approval).
-- Consider expanding the bot's availability for other wiki Discords with similar needs.
+| Command | Description |
+|---|---|
+| `/archive this` | Archive the current thread |
+| `/archive thread <id>` | Archive a specific thread by ID |
+| `/close` | Close a meme proposal (vote count, archive, wiki edits) |
+| `/allowed_channels` | Manage which channels can be archived |
+| `/allowed_roles` | Manage which roles can use bot commands |
+| `/verified_members` | Manage Discord-to-wiki account mappings |
 
-## Setup and Commands
+### `/close` Options
 
-For a **full list of commands** and detailed setup instructions, please refer to our [**Documentation Page**](/docs/commands-and-setup.md). This includes step-by-step guides on how to install, configure, and use the bot effectively.
+| Option | Required | Description |
+|---|---|---|
+| `vote_result` | Yes | Outcome: `support`, `oppose`, `restructure`, or `null` |
+| `summary` | Yes | Short summary of the decision |
+| `support_count` | No | Override bot's detected support count |
+| `oppose_count` | No | Override bot's detected oppose count |
+| `restructure_count` | No | Override bot's detected restructure count |
+
+## Setup
+
+1. Clone the repository and run `npm install`.
+2. Copy `.env.example` or create `.env` with the variables listed above.
+3. Register commands with Discord: `npm run register`.
+4. Start the bot: `npm start` (or `npm run dev` for development with auto-reload).
+
+## Testing
+
+```bash
+npm test
+```
+
+Tests cover vote counting (using real wiki log fixtures), threshold evaluation, ordinal date formatting, and wikitext generation.
+
+## Project Structure
+
+```
+app.js            Express server, interaction routing
+archive.js        Thread reading, message formatting, SQLite DB
+close.js          /close command handler (preview, confirm, execute)
+votecount.js      Vote counting, strikethrough detection, threshold evaluation
+wiki.js           MediaWiki API client (login, read, edit)
+wikiformat.js     Wikitext generation (log titles, archive entries, scaffolds)
+commands.js       Slash command definitions + registration
+markdown.js       Discord markdown to wikitext conversion
+utils.js          Discord API helpers
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ DiscordWikitextArchive is a Discord bot designed to archive specific discussion 
     - Best-effort vote counting with strikethrough crossout detection.
     - Threshold evaluation (75% majority, 7 voter minimum).
     - Preview of all planned changes with confirm/cancel buttons.
-    - Discord thread management (rename with `[CLOSED]`, lock).
-    - Wiki page edits via MediaWiki API: create log page, update archive, update proposals page, scaffold to-do and progress entries.
+    - Discord thread management: rename with `[CLOSED]`/`[NULL]` prefix, apply forum tag (approved/rejected/restructured/not enough votes/closed), archive, and lock.
+    - Wiki page edits via MediaWiki API: create log page, update archive, insert row in proposals table, scaffold to-do and progress entries.
+    - Links to all created/modified wiki pages in the result message.
 - **Privacy Controls**: Restricts commands to authorized roles and specific channels.
 - **Participant Mapping**: Maps verified Discord members to their wiki accounts via `/verified_members`.
 
@@ -60,7 +61,7 @@ This project was born out of a need to streamline the logging process for a popu
 
 | Option | Required | Description |
 |---|---|---|
-| `vote_result` | Yes | Outcome: `support`, `oppose`, `restructure`, or `null` |
+| `vote_result` | Yes | Outcome: `support`, `oppose`, `restructure`, `null`, or `closed` |
 | `summary` | Yes | Short summary of the decision |
 | `support_count` | No | Override bot's detected support count |
 | `oppose_count` | No | Override bot's detected oppose count |
@@ -79,7 +80,7 @@ This project was born out of a need to streamline the logging process for a popu
 npm test
 ```
 
-Tests cover vote counting (using real wiki log fixtures), threshold evaluation, ordinal date formatting, and wikitext generation.
+Tests cover vote counting (using real wiki log fixtures), threshold evaluation, wikitext generation (proposals rows, archive entries, to-do/progress scaffolds), and ordinal date formatting.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This project was born out of a need to streamline the logging process for a popu
 | `PUBLIC_KEY` | Discord public key for interaction verification |
 | `GUILD_ID` | Discord server (guild) ID |
 | `WIKI_API_URL` | MediaWiki API endpoint (e.g. `https://siivagunner.wiki/w/api.php`) |
-| `WIKI_USERNAME` | MediaWiki bot account username |
+| `WIKI_USERNAME` | MediaWiki bot password login name (e.g. `Username@BotPasswordName`) |
 | `WIKI_PASSWORD` | MediaWiki bot password |
 
 ## Commands
@@ -73,6 +73,27 @@ This project was born out of a need to streamline the logging process for a popu
 2. Copy `.env.example` or create `.env` with the variables listed above.
 3. Register commands with Discord: `npm run register`.
 4. Start the bot: `npm start` (or `npm run dev` for development with auto-reload).
+
+### Discord Bot Permissions
+
+The bot requires the following OAuth2 scopes and permissions:
+
+- **Scopes**: `bot`, `applications.commands`
+- **Permissions**: Manage Roles, Manage Threads, Read Message History, Send Messages, View Channels
+
+For `/close` to rename, tag, archive, and lock threads, the bot must have **Manage Threads** access on the specific forum channel (check channel-level permission overrides).
+
+### Wiki Page Markers
+
+The `/close` command inserts rows into wiki tables by looking for specific HTML comment markers. Add these to the relevant wiki pages:
+
+- **Proposals page** (`SiIvaGunner Wiki:Meme discussion`): `<!--New row goes here-->` before the table's closing `|}`
+- **To-do list** (`SiIvaGunner Wiki:Meme discussion/Meme discussion to-do list`): `<!-- Scaffolding` before the scaffold comment block
+- **Progress page** (`SiIvaGunner Wiki:Meme discussion/Progress`): `<!-- ...New entries...` before the new entries comment block
+
+### Forum Tags
+
+The bot applies forum tags based on vote result. The forum channel should have tags named (case-insensitive): **approved**, **rejected**, **restructured**, **not enough votes**, **closed**.
 
 ## Testing
 

--- a/__tests__/fixtures/dougie.txt
+++ b/__tests__/fixtures/dougie.txt
@@ -1,0 +1,233 @@
+<templatestyles src="Template:DiscordLog/styles.css"/>
+{{DiscordLog2|class=date-separator|t=April 14, 2025}}
+{{DiscordLog2|t= 16:42|1=Nuc1eusknight|2=Teach Me How to Dougie is a song by Cali Swag District. It released on April 13, 2010, and became a hit in the United States. I believe it should be considered a minor meme on SiIvaGunner. There are currently 33 rips that feature Teach Me How to Dougie, either as the main joke or as part of a medley mashup. It has 3 rips dating all the way back to GiIvaSunner era, but wouldn't see much usage until 2020 when it was picked up again. It would appear occasionally throughout the years, with 3 rips in 2022 and 4 rips in 2023, but would eventually see peak usage during 2024, with 19 rips. Although it hasn't appeared since Season 8, I still believe there's enough history surrounding this song on the channel that deserves an article, documenting it as a minor meme.
+
+Playlist: https://youtube.com/playlist?list=PLw10xqS3ODR8Ktv4UaybuBeKDC6OeNpEK&si=Ut-PlLUxE4jaZiP5
+
+[[File:Voting-support.svg|20px|link=]]}}
+{{DiscordLog2|t= 15:58|1=Mick the Squirrel|2=<blockquote>''Forwarded:''
+[[File:Voting-oppose.svg|20px|link=]] goofy
+it's best to wait and see if this actually does anything rather than documenting ''just because''. timeline is kinda minor too...</blockquote>}}
+{{DiscordLog2|t= 16:43|1=Eden342|2=They be like N (what?)
+Can you teach me how to Dougie?
+me: [[File:Voting-support.svg|20px|link=]]}}
+{{DiscordLog2|t= 16:43|1=Stump-7|2=[[File:Voting-support.svg|20px|link=]] dougie}}
+{{DiscordLog2|t= 16:44|1=Mick the Squirrel|2=wait 19}}
+{{DiscordLog2|t= 16:44|1=Mick the Squirrel|2=hmm}}
+{{DiscordLog2|t= 16:44|1=Eden342|2=[[User:Nuc1eusknight|krismover]] Don't forget to vote on your own proposal.}}
+{{DiscordLog2|t= 16:44|1=Stump-7|2=yeah}}
+{{DiscordLog2|t= 16:45|1=Stump-7|2=just edit the support emoji in your proposal message}}
+{{DiscordLog2|t= 16:45|1=Stump-7|2=or something}}
+{{DiscordLog2|class=ping reply|1=Mick the Squirrel|2=wait 19}}
+{{DiscordLog2|t= 16:45|1=Mick the Squirrel|2=okay homecoming day}}
+{{DiscordLog2|t= 16:45|1=Nuc1eusknight|2=got u}}
+{{DiscordLog2|t= 16:46|1=Eden342|2=26 rips outside of homecoming}}
+{{DiscordLog2|t= 16:46|1=Mick the Squirrel|2=yeah i can't exactly call it an event source}}
+{{DiscordLog2|t= 16:46|1=Nuc1eusknight|2=a good amount of 2024 usage is split between homecoming and general}}
+{{DiscordLog2|t= 16:46|1=Nuc1eusknight|2=so not exactly event meme no}}
+{{DiscordLog2|t= 16:47|1=Mick the Squirrel|2=even outside of that i'd prefer if there were something real to write}}
+{{DiscordLog2|t= 16:47|1=Mick the Squirrel|2=if we had a "weak oppose" i'd choose that.}}
+{{DiscordLog2|class=ping reply|1=Mick the Squirrel|2=if we had a "weak oppose" i'd choose that.}}
+{{DiscordLog2|t= 16:47|1=Notascryptic|2=what would that even do}}
+{{DiscordLog2|t= 16:48|1=Eden342|2=most useless emoji ever bru}}
+{{DiscordLog2|class=ping reply|1=Notascryptic|2=what would that even do}}
+{{DiscordLog2|t= 16:48|1=Mick the Squirrel|2=wikipedia has those}}
+{{DiscordLog2|t= 16:48|1=Mick the Squirrel|2=it serves the point of being a more nuanced opinion but i guess my words get that across}}
+{{DiscordLog2|t= 16:49|1=Notascryptic|2=i’m still confused on what it actually counts as}}
+{{DiscordLog2|t= 16:49|1=Notascryptic|2=when you tally up the votes}}
+{{DiscordLog2|t= 16:50|1=Eden342|2=extra percentage!}}
+{{DiscordLog2|t= 16:50|1=Mick the Squirrel|2=itd tally the same}}
+{{DiscordLog2|t= 16:50|1=Notascryptic|2=an oppose is an oppose}}
+{{DiscordLog2|t= 16:51|1=Heboyi|2=teach me how to douglass}}
+{{DiscordLog2|t= 16:52|1=Heboyi|2=[[File:Voting-support.svg|20px|link=]] that gets a per alla that i guess}}
+{{DiscordLog2|class=ping reply|1=Mick the Squirrel|2=if we had a "weak oppose" i'd choose that.}}
+{{DiscordLog2|t= 16:53|1=TurretBot|2=[[File:Voting-neutral.svg|20px|link=]]}}
+{{DiscordLog2|t= 16:53|1=Mick the Squirrel|2=no value in meme discussion}}
+{{DiscordLog2|t= 16:53|1=TurretBot|2=it's a weak oppose}}
+{{DiscordLog2|t= 16:53|1=Nuc1eusknight|2=i dont think that necessarily gets the point across}}
+{{DiscordLog2|t= 16:53|1=Mick the Squirrel|2=and soon, no value at all.......}}
+{{DiscordLog2|t= 16:53|1=Eden342|2=chill}}
+{{DiscordLog2|class=ping reply|1=Mick the Squirrel|2=no value in meme discussion}}
+{{DiscordLog2|t= 16:53|1=Notascryptic|2=its as valuable as a weak oppose}}
+{{DiscordLog2|t= 16:53|1=Game Controller|2=[[File:Voting-support.svg|20px|link=]] it has enough rips for me to consider it}}
+{{DiscordLog2|t= 16:53|1=Eden342|2=im gonna miss it}}
+{{DiscordLog2|t= 16:54|1=Notascryptic|2=[[File:Voting-support.svg|20px|link=]] take my support}}
+{{DiscordLog2|t= 16:55|1=TurretBot|2=weak oppose}}
+{{DiscordLog2|t= 16:55|1=TurretBot|2=and restructure is weak support}}
+{{DiscordLog2|t= 16:55|1=GargameNga2025|2=they should rebrand to that fr}}
+{{DiscordLog2|t= 16:55|1=Nuc1eusknight|2=wait that might be meta}}
+{{DiscordLog2|class=ping reply|1=TurretBot|2=and restructure is weak support}}
+{{DiscordLog2|t= 16:56|1=Heboyi|2=ur mental}}
+{{DiscordLog2|t= 16:57|1=GargameNga2025|2=idrk how to feel about dougie rn}}
+{{DiscordLog2|t= 17:01|1=Picaloyouhavenosauce|2=[[File:Voting-support.svg|20px|link=]] its minor but thats fine}}
+{{DiscordLog2|t= 17:07|1=Madotsuki417|2=[[File:Voting-support.svg|20px|link=]] agreeed}}
+{{DiscordLog2|t= 17:22|1=E for Affort|2=mysikt meme that siiva uses sometimes}}
+{{DiscordLog2|t= 17:22|1=E for Affort|2=[[File:Voting-support.svg|20px|link=]]}}
+{{DiscordLog2|t= 20:00|1=Navag8r|2=they're robbing us blind fr}}
+{{DiscordLog2|t= 20:02|1=TurretBot|2=many such cases}}
+{{DiscordLog2|t= 20:14|1=Brunocoolgamers|2=[[File:Voting-support.svg|20px|link=]] agreed}}
+{{DiscordLog2|class=ping reply|1=E for Affort|2=mysikt meme that siiva uses sometimes}}
+{{DiscordLog2|t= 20:16|1=Mick the Squirrel|2=this just makes me sadder
+siiva does not need an article on everything
+let the fanchannels keep their sauce}}
+{{DiscordLog2|t= 20:18|1=TurretBot|2=you should go rip by rip and figure out which ones are substantial}}
+{{DiscordLog2|t= 20:34|1=Navag8r|2=it's interesting that siiva peak usage for dougie is at the same time as mysikt peak usage for dougie}}
+{{DiscordLog2|t= 20:34|1=Navag8r|2=chat clip that}}
+{{DiscordLog2|t= 20:38|1=Brunocoolgamers|2=i had no idea dougie was a mysikt thing until someone brought it up here so i think pages explaning this stuff are useful actually}}
+{{DiscordLog2|t= 20:39|1=Brunocoolgamers|2=and i seen a lot of people express this setiment too}}
+{{DiscordLog2|t= 21:45|1=Picaloyouhavenosauce|2=i think teach me how to doguie has usage that stands on its own when viewed apart from mysikt that a fanchannel meme like pop champagne does not}}
+{{DiscordLog2|t= 22:13|1=Navag8r|2=yeah i dont think mysikt should affect whether this is classed as a meme on the wiki}}
+{{DiscordLog2|t= 22:13|1=Navag8r|2=just being a lil snarky}}
+{{DiscordLog2|t= 22:43|1=ThisGreenDingo|2=This one’s hard}}
+{{DiscordLog2|t= 22:43|1=ThisGreenDingo|2=so i probably wont vote}}
+{{DiscordLog2|class=ping reply|1=Navag8r|2=it's interesting that siiva peak usage for dougie is at the same time as mysikt peak usage for dougie}}
+{{DiscordLog2|t= 05:34|1=GoldM|2=I think its probably by the same people on both channels}}
+{{DiscordLog2|t= 05:34|1=GoldM|2=At least in 2023}}
+{{DiscordLog2|t= 05:34|1=GoldM|2=I will not vote on this one}}
+{{DiscordLog2|t= 05:37|1=GoldM|2=But I don't personally consider it a SiIva meme and I dont think it has that much of a notable presence compared to Rolex but maybe thats influenced by bias on what I saw/noticed + outside context
+Therefore no vote}}
+{{DiscordLog2|class=date-separator|t=April 15, 2025}}
+{{DiscordLog2|t= 10:22|1=Nuc1eusknight|2=so a funny thing just happened https://youtu.be/S8HoRusBnj4}}
+{{DiscordLog2|t= 10:22|1=Nuc1eusknight|2=make that 34 rips total}}
+{{DiscordLog2|t= 10:22|1=Nuc1eusknight|2=LMAO}}
+{{DiscordLog2|t= 10:22|1=Nuc1eusknight|2=and i believe its first appearance since s8}}
+{{DiscordLog2|t= 11:44|1=Navag8r|2=schedulers are always watching i assume}}
+{{DiscordLog2|t= 15:05|1=Nuc1eusknight|2=tru}}
+{{DiscordLog2|class=date-separator|t=April 16, 2025}}
+{{DiscordLog2|t= 23:14|1=Chickennugget12352|2=[[File:Voting-support.svg|20px|link=]] yup}}
+{{DiscordLog2|t= 01:46|1=ThisGreenDingo|2=[[File:Voting-oppose.svg|20px|link=]] weak oppose based on mick’s point of patience}}
+{{DiscordLog2|class=date-separator|t=April 17, 2025}}
+{{DiscordLog2|class=ping reply|1=ThisGreenDingo|2=[[File:Voting-oppose.svg|20px|link=]] weak oppose based on mick’s point of patience}}
+{{DiscordLog2|t= 02:45|1=E for Affort|2=do you just reject every good meme suggestion}}
+{{DiscordLog2|t= 02:46|1=Eden342|2=CHILL ON DINGO!}}
+{{DiscordLog2|t= 02:46|1=TurretBot|2=ad hominem}}
+{{DiscordLog2|class=ping reply|1=E for Affort|2=do you just reject every good meme suggestion}}
+{{DiscordLog2|t= 02:46|1=Mick the Squirrel|2=do you just fall to the whims of the crowd and applaud whatever norm is set in front of you}}
+{{DiscordLog2|t= 02:47|1=Mick the Squirrel|2=slash lh
+im not trying to sound evil all the time}}
+{{DiscordLog2|t= 02:48|1=TurretBot|2=thats also a personal attack}}
+{{DiscordLog2|t= 02:49|1=Mick the Squirrel|2=a stranger attempted to teach me how to dougie when i was a child}}
+{{DiscordLog2|t= 02:50|1=TurretBot|2=have i voted in this thread}}
+{{DiscordLog2|t= 02:50|1=Eden342|2=i said get down low and swing your arm}}
+{{DiscordLog2|class=ping reply|1=TurretBot|2=[[File:Voting-neutral.svg|20px|link=]]}}
+{{DiscordLog2|t= 02:50|1=Mick the Squirrel|2=a fake vote}}
+{{DiscordLog2|t= 02:50|1=TurretBot|2=that was just a response not a vote}}
+{{DiscordLog2|class=ping reply|1=Eden342|2=i said get down low and swing your arm}}
+{{DiscordLog2|t= 02:50|1=Eden342|2=i did the wrong sonf}}
+{{DiscordLog2|t= 02:51|1=Heboyi|2=they can share a page}}
+{{DiscordLog2|t= 02:51|1=Mick the Squirrel|2=joke failed and quan will be rejected}}
+{{DiscordLog2|t= 02:51|1=Eden342|2=LOL}}
+{{DiscordLog2|t= 02:51|1=Eden342|2=quan is not being rejected bruh}}
+{{DiscordLog2|t= 02:51|1=Eden342|2=thats like deleting snow halation}}
+{{DiscordLog2|t= 02:51|1=TurretBot|2=tempted to go rip by rip but also not really cuz of laziness}}
+{{DiscordLog2|class=ping reply|1=Eden342|2=quan is not being rejected bruh}}
+{{DiscordLog2|t= 02:51|1=Mick the Squirrel|2=because people forgot about critical thinking
+i need Corb level analysis in here come on}}
+{{DiscordLog2|t= 02:51|1=TurretBot|2=teach me how to dougie lined up with the snow halation rip i was listening to that was kinda magical}}
+{{DiscordLog2|t= 02:52|1=Eden342|2=wow}}
+{{DiscordLog2|class=ping reply|1=TurretBot|2=tempted to go rip by rip but also not really cuz of laziness}}
+{{DiscordLog2|t= 02:52|1=Heboyi|2=i counted it out and it was like 15 where dougie was not the/a main focus and 11 of those were medleys or something}}
+{{DiscordLog2|t= 02:53|1=Heboyi|2=i forgot because i closed my notepad doc}}
+{{DiscordLog2|t= 02:53|1=TurretBot|2=wow}}
+{{DiscordLog2|t= 02:53|1=TurretBot|2=thats like half}}
+{{DiscordLog2|t= 02:57|1=TurretBot|2=we can probably put on the article that its used in medley rips and solo rips idk}}
+{{DiscordLog2|t= 02:57|1=TurretBot|2=weak support?}}
+{{DiscordLog2|t= 00:03|1=Heboyi|2=<blockquote>''Forwarded:''
+That's how we rep stuff</blockquote>}}
+{{DiscordLog2|t= 03:01|1=Heboyi|2=this is like my stance so my counting didnt really change my stance}}
+{{DiscordLog2|t= 03:04|1=Heboyi|2=its also a rap mashup source that has basically no melodic elements so its not gonna have as many solo reps due to that}}
+{{DiscordLog2|class=ping reply|1=Mick the Squirrel|2=because people forgot about critical thinking
+i need Corb level analysis in here come on}}
+{{DiscordLog2|t= 03:05|1=CorbCreates|2=fineeeeeeeeeeeee}}
+{{DiscordLog2|t= 03:05|1=Mick the Squirrel|2=:D}}
+{{DiscordLog2|t= 03:05|1=CorbCreates|2=ive been putting off doing my looking into these memes for a bit due to schoolwork}}
+{{DiscordLog2|t= 03:06|1=Eden342|2=prediction oppose and everyone changes votes}}
+{{DiscordLog2|t= 03:06|1=Mick the Squirrel|2=well dont force yourself then}}
+{{DiscordLog2|t= 03:06|1=Mick the Squirrel|2=IF YOU'RE GOING TO DO ONE CORB PLEASE DO THE PAUL THREAD}}
+{{DiscordLog2|t= 03:06|1=Eden342|2=LOL}}
+{{DiscordLog2|t= 03:07|1=Eden342|2=i thought he already voted there}}
+{{DiscordLog2|t= 03:07|1=CorbCreates|2=nah i havent voted in any of the current open threads besides puzzle room bc all te good research was done for me}}
+{{DiscordLog2|t= 03:34|1=CorbCreates|2=Group 1 - Giiva/Early Siiva - 3 rips. Very possible references to each other. Dougie is 6 full years old even back then so its fair to call this part of a trend, if it were to continue.
+Sandwich Maker - 2017. Kinda isolated. Nothing really close to it and very irrelevant.
+Group 3 - 2020 - 2 rips. These rips are so close to each other its kinda insane. the second rip was probably influenced by the first.
+Desert Theme - 2021. Also isolated. Probably just used because it is a known song.
+Group 5 - 2022-2024 - 26 Rips. This trend starts super slowly to the point that it is difficult to tell whether it is a trend in the first place, before picking up into 2023 and 2024. The singular 2025 rip is too isolated to coorelate with this group.
+
+Bonus - the 3D all stars rip references one of the 2016 rips. A lot of these rips are solo usages, or in conspicuous spots that feel like meme usages. Also, the quan pairing occuring many times can confidently be coorelated with previous rips inspiring later rips of the song. This is not due to external popularity.
+
+Overall, I am going to [[File:Voting-support.svg|20px|link=]] because even though the meme is definitely used sparsely, there is a clear trend and a notable amount of references to previous usages that would make much more sense if dougie was a meme.}}
+{{DiscordLog2|t= 03:35|1=CorbCreates|2=it is definitely borderline, but early usage being that sparse only to be followed by this uptick for a notable period of time is good enough}}
+{{DiscordLog2|t= 03:36|1=Eden342|2=bro was taught how to dougie}}
+{{DiscordLog2|t= 03:37|1=Heboyi|2=don't cry mick, it'll all be okay}}
+{{DiscordLog2|t= 03:37|1=Mick the Squirrel|2=no it won't}}
+{{DiscordLog2|t= 03:37|1=Mick the Squirrel|2=and good on you for not reciting monsters v aliens twitter meme from those first two words}}
+{{DiscordLog2|t= 03:37|1=CorbCreates|2=patience is pointless really bc unless there are more dougie/quan rips the trend is kinda over}}
+{{DiscordLog2|t= 03:38|1=CorbCreates|2=its either a meme or not}}
+{{DiscordLog2|t= 03:39|1=GargameNga2025|2=<s>i mean fuck it if minions r in why not [[File:Voting-support.svg|20px|link=]]</s> lied}}
+{{DiscordLog2|t= 03:39|1=CorbCreates|2=dont let minions being in bias you}}
+{{DiscordLog2|t= 03:41|1=GargameNga2025|2=i like consistency so it will influence me at least a little bit}}
+{{DiscordLog2|t= 03:41|1=GargameNga2025|2=this is far more defined to me either way tho its clearly more of Something}}
+{{DiscordLog2|t= 03:41|1=CorbCreates|2=if you want the trend flipped deep in your heart, vote against}}
+{{DiscordLog2|t= 03:42|1=GargameNga2025|2=it wont get flipped cuz im not powerful enough}}
+{{DiscordLog2|t= 03:57|1=TurretBot|2=thats just politics}}
+{{DiscordLog2|t= 03:57|1=TurretBot|2=invalidate the thread}}
+{{DiscordLog2|t= 04:00|1=TurretBot|2=corb always has the best takes}}
+{{DiscordLog2|t= 04:01|1=TurretBot|2=:Support: just make sure the article is based on corb's text cuz it basically says everything there is to say}}
+{{DiscordLog2|class=ping reply|1=TurretBot|2=corb always has the best takes}}
+{{DiscordLog2|t= 04:03|1=Heboyi}}
+{{DiscordLog2|t= 04:03|1=Mick the Squirrel|2=how many of these do you have}}
+{{DiscordLog2|t= 04:03|1=Eden342|2=LOL}}
+{{DiscordLog2|t= 04:03|1=TurretBot|2=this one isnt even an emote}}
+{{DiscordLog2|t= 04:04|1=TurretBot|2=[[User:Heboyi|heboyi]] add me to the emote server}}
+{{DiscordLog2|t= 04:04|1=CorbCreates|2=bro i JUST changed my pfp i cant change it again immediately after}}
+{{DiscordLog2|t= 04:04|1=CorbCreates|2=I will save this for later}}
+{{DiscordLog2|class=ping reply|1=TurretBot|2=[[User:Heboyi|heboyi]] add me to the emote server}}
+{{DiscordLog2|t= 04:04|1=Heboyi|2=restructure land logged forever on the wiki}}
+{{DiscordLog2|t= 04:05|1=TurretBot|2=just do it}}
+{{DiscordLog2|class=ping reply|1=TurretBot|2=thats just politics}}
+{{DiscordLog2|t= 04:05|1=GargameNga2025|2=its always politics}}
+{{DiscordLog2|t= 04:06|1=Heboyi|2=teach me how to dougie is a meme that doesn't need its proposal restructured thats my stance this isn't off topic}}
+{{DiscordLog2|class=ping reply|1=Heboyi}}
+{{DiscordLog2|t= 04:31|1=ThisGreenDingo|2=piss restructure?}}
+{{DiscordLog2|t= 04:33|1=TurretBot|2=filename}}
+{{DiscordLog2|t= 04:33|1=Heboyi|2=why does everyone think corb is pee}}
+{{DiscordLog2|class=ping reply|1=ThisGreenDingo|2=piss restructure?}}
+{{DiscordLog2|t= 04:33|1=CorbCreates|2=PLEASE drink more water}}
+{{DiscordLog2|class=ping reply|1=CorbCreates|2=PLEASE drink more water}}
+{{DiscordLog2|t= 04:35|1=ThisGreenDingo|2=I was referring to yours}}
+{{DiscordLog2|t= 04:35|1=ThisGreenDingo|2=If it was mine itd be a transparent restructure}}
+{{DiscordLog2|t= 06:23|1=Nuc1eusknight|2=douger}}
+{{DiscordLog2|class=ping reply|1=CorbCreates|2=Group 1 - Giiva/Early Siiva - 3 rips. Very possible references to each other. Dougie is 6 full years old even back then so its fair to call this part of a trend, if it were to continue.
+Sandwich Maker - 2017. Kinda isolated. Nothing really close to it and very irrelevant.
+Group 3 - 2020 - 2 rips. These rips are so close to each other its kinda insane. the second rip was probably influenced by the first.
+Desert Theme - 2021. Also isolated. Probably just used because it is a known song.
+Group 5 - 2022-2024 - 26 Rips. This trend starts super slowly to the point that it is difficult to tell whether it is a trend in the first place, before picking up into 2023 and 2024. The singular 2025 rip is too isolated to coorelate with this group.
+
+Bonus - the 3D all stars rip references one of the 2016 rips. A lot of these rips are solo usages, or in conspicuous spots that feel like meme usages. Also, the quan pairing occuring many times can confidently be coorelated with previous rips inspiring later rips of the song. This is not due to external popularity.
+
+Overall, I am going to [[File:Voting-support.svg|20px|link=]] because even though the meme is definitely used sparsely, there is a clear trend and a notable amount of references to previous usages that would make much more sense if dougie was a meme.}}
+{{DiscordLog2|t= 06:24|1=Nuc1eusknight|2=yea u basically summed up everything i thought in a much more appealing way lmao}}
+{{DiscordLog2|t= 06:24|1=Nuc1eusknight|2=nice}}
+{{DiscordLog2|class=date-separator|t=April 21, 2025}}
+{{DiscordLog2|t= 17:00|1=Eden342|2=Final Tally
+—————
+[[File:Voting-support.svg|20px|link=]] (86.7%)
+* lucas
+* N
+* Stump
+* Heboyi
+* MaximumRK
+* coolguy
+* circunflexo
+* Memmy
+* E For Affort
+* bruno
+* chickennugget
+* Corb
+* TurretBot
+[[File:Voting-oppose.svg|20px|link=]] (13.3%)
+* Mick
+* Dingo
+13 support, 2 oppose.
+Decision: '''Accepted.'''}}
+{{DiscordLog2|t= 17:00|1=Eden342|2=[CLOSED] Teach Me How to Dougie is a meme}}

--- a/__tests__/fixtures/meatball_parade.txt
+++ b/__tests__/fixtures/meatball_parade.txt
@@ -1,0 +1,258 @@
+<templatestyles src="Template:DiscordLog/styles.css"/>
+{{DiscordLog2|class=date-separator|t=July 22, 2025}}
+{{DiscordLog2|t= 16:24|1=Archimedes4047|2=The song has had multiple usages, mostly in arrangement of the advertised tracks but does have [https://youtu.be/wMbG2LHzpdY&t=2698 two] [https://youtu.be/S3mQJ7wxNwo rips] that are melody changes (one's in a medley rip and the other just has another Kevin MacLeod song), there's also 2 usages in fusion collabs.
+
+According to a playlist, there's 25 rips using Meatball Parade:
+https://youtube.com/playlist?list=PL9DFnrgxHR47vYQcHFkT3LeZjJxwxvF6x
+
+The songs usage seems to mainly be in season 6 and season 7, but seems to have had a sort of resurgence recently (the era being probably season 6 or 7). [[File:Voting-support.svg|20px|link=]]}}
+{{DiscordLog2|t= 16:34|1=Rickhenrique|2=[[File:Voting-restructure.svg|20px|link=]] While I believe "Meatball Parade" feels like somewhat of a frequent use, the best approach is to make Kevin MacLeod a meme, as since "Meatball Parade" isn't the only frequent track and it appears more to being a part of Kevin MacLeod's usages}}
+{{DiscordLog2|t= 16:39|1=Brunocoolgamers|2=Big disagree on that}}
+{{DiscordLog2|t= 16:40|1=Brunocoolgamers|2=Meatball parade has an era it started being used in and its used in a quite different way than other macleod songs since its an flp arrange thing and overall the trend feels comeply unreletead}}
+{{DiscordLog2|t= 16:41|1=Rickhenrique|2=Not to mention that many of Kevin Macleod's song is heavy used, in which includes "Sneaky Adventure" being somewhat a frequent contenter as well (ignoring the fact that this list is likely incomplete on it's own)
+As well in some other factors, like:
+* "Sneaky Adventure" being used for the Mr. Incredible Becomes Uncanny meme
+* Already one of the sources used during Unregistered HyperCam 2 Takeover
+* And overall, "Meatball Parade" having less rips and frequent usage if goes by date instead of quantity of rips}}
+{{DiscordLog2|t= 16:42|1=Rickhenrique|2=Cannot deny to be a meme, but it should be better be part of Kevin MacLeod source overall}}
+{{DiscordLog2|class=ping reply|1=Rickhenrique|2=[[File:Voting-restructure.svg|20px|link=]] While I believe "Meatball Parade" feels like somewhat of a frequent use, the best approach is to make Kevin MacLeod a meme, as since "Meatball Parade" isn't the only frequent track and it appears more to being a part of Kevin MacLeod's usages}}
+{{DiscordLog2|t= 16:43|1=Archimedes4047|2=I was honestly debating making the proposal about Kevin MacLeod's music as a whole being a meme or just Meatball Parade, I can see him being a meme instead of just Meatball Parade.}}
+{{DiscordLog2|t= 16:45|1=Rickhenrique|2=Yeah, for me any of the songs of Kevin being a meme feels kinda farfetch, considering that it doesn't use often when it's solo by comparasion, and again, it feels more part of a whole multi-media rather than solo meme, as since many of them are very noticebly reconizeble and also due to "Sneaky Adventure" has somewhat of a noticeble usage thanks to Uncanny Incredible}}
+{{DiscordLog2|t= 16:45|1=Brunocoolgamers|2=Anyways i [[File:Voting-support.svg|20px|link=]] i didnt see it last time but now that it even has a joke game i def think its a meme}}
+{{DiscordLog2|t= 16:46|1=Brunocoolgamers|2=Sneaky adventure can just go under mr incredible when appiclable and none of the other songs are notable really}}
+{{DiscordLog2|t= 16:48|1=Brunocoolgamers|2=Plus yeah its been having a minor revival lately}}
+{{DiscordLog2|t= 16:48|1=Rickhenrique|2=well that's the only view I see, as well that Super Meatball only has one rip, in which should be fine but not something big like Hall of the Mountain Kingdom with one of the joke games
+but that's my view}}
+{{DiscordLog2|t= 18:11|1=Eden342|2=[[File:Voting-support.svg|20px|link=]] yea}}
+{{DiscordLog2|t= 18:26|1=Navag8r|2=hmm as #1 meatball parade warrior atm i still dont think we're there yet, i can see it being a sub-meme of kevin macleod but not on its own ''yet''.}}
+{{DiscordLog2|t= 18:34|1=Eden342|2=kevin macleod definitely shouldnt be the meme}}
+{{DiscordLog2|t= 18:52|1=FunniiXD|2=[[File:Voting-support.svg|20px|link=]] yeah}}
+{{DiscordLog2|t= 18:57|1=Heboyi|2=meatball parade’s usage within the broad kevin macleod bubble is more disproportionate to its actual outside popularity than like any other kevin songs usage imo}}
+{{DiscordLog2|t= 18:59|1=Heboyi|2=like i’d see the argument for it just being a broad kevin macleod source if it was a song out of his catalog that is insanely popular like monkey spinning monkeys or scheming weasel but meatball parade isn’t really that}}
+{{DiscordLog2|t= 19:00|1=FunniiXD|2=yeah meatball is a specific song}}
+{{DiscordLog2|t= 22:12|1=Ryrie36|2=I'll think about it but I definitely know that Kevin Macleod himself doesn't feel like a meme}}
+{{DiscordLog2|t= 23:48|1=ThisGreenDingo|2=[[File:Voting-oppose.svg|20px|link=]] what are you doing}}
+{{DiscordLog2|t= 23:49|1=ThisGreenDingo|2=i thought this was figured out months ago}}
+{{DiscordLog2|class=ping reply|1=ThisGreenDingo|2=[[File:Voting-oppose.svg|20px|link=]] what are you doing}}
+{{DiscordLog2|t= 23:49|1=Eden342|2=robbie rotten speech bubble}}
+{{DiscordLog2|t= 23:56|1=GargameNga2025|2=[[File:Voting-support.svg|20px|link=]] it didnt rly make sense that everyone rejected it before so im just gonna support on the basis of that}}
+{{DiscordLog2|t= 00:05|1=Nuc1eusknight|2=imma be honest idk how to tackle this}}
+{{DiscordLog2|t= 00:20|1=FunniiXD|2=why are people so iffy about it}}
+{{DiscordLog2|t= 00:22|1=CorbCreates|2=bc macleod songs are fairly well known}}
+{{DiscordLog2|t= 00:22|1=FunniiXD|2=I think good points were made that its too specific of a source to be mushed into a kevin macleod category meatball parade isn't that big guys}}
+{{DiscordLog2|t= 00:22|1=GargameNga2025|2=it wasnt used all within the span of liek 3 weeks}}
+{{DiscordLog2|t= 00:22|1=ThisGreenDingo|2=this cant fly surely like what the hey}}
+{{DiscordLog2|class=ping reply|1=GargameNga2025|2=it wasnt used all within the span of liek 3 weeks}}
+{{DiscordLog2|t= 00:23|1=Eden342|2=LOL}}
+{{DiscordLog2|class=ping reply|1=CorbCreates|2=bc macleod songs are fairly well known}}
+{{DiscordLog2|t= 00:25|1=FunniiXD|2=meatball parade again feels too specific and different with its arrangements we don't actively get arrangements of other fls of kevin songs}}
+{{DiscordLog2|t= 00:26|1=FunniiXD|2=also like bruno said it has an era worth documenting}}
+{{DiscordLog2|class=ping reply|1=Heboyi|2=meatball parade’s usage within the broad kevin macleod bubble is more disproportionate to its actual outside popularity than like any other kevin songs usage imo}}
+{{DiscordLog2|t= 00:26|1=Heboyi|2=my current stance is support but imma wait until the discussion has run dry and a decision is practically already there to actually support it because Conflict of Interest}}
+{{DiscordLog2|t= 00:29|1=GargameNga2025|2=i think the only real argument against it i can think of is just that its a General Ripping Community Meme and not the most specific to siiva but liek its not specific to another channel either   its probably worth documenting}}
+{{DiscordLog2|t= 00:29|1=FunniiXD|2=where did it start anyway}}
+{{DiscordLog2|t= 00:29|1=CorbCreates|2=its hard bc 25 rips over 3 years is very borderline. but like 0 rips prior to that for a 10yo song does make it feel like a trend}}
+{{DiscordLog2|t= 00:30|1=CorbCreates|2=im gonna have to do my usual analysis for this to really come to a decision for MP vs. Macleod vs Neither as the meme}}
+{{DiscordLog2|t= 00:31|1=ThisGreenDingo|2=I feel like if theres any doubt just skip out i dont see how a case like this is worth the effort}}
+{{DiscordLog2|t= 00:31|1=Eden342|2=macleod is absolutely not the meme idc what else happens in this proposal i just dont want that}}
+{{DiscordLog2|class=ping reply|1=GargameNga2025|2=i think the only real argument against it i can think of is just that its a General Ripping Community Meme and not the most specific to siiva but liek its not specific to another channel either   its probably worth documenting}}
+{{DiscordLog2|t= 00:31|1=Brunocoolgamers|2=arguments like this are dumb beacuse yeah of course ripping community trends are gonna reach siiva}}
+{{DiscordLog2|t= 00:31|1=FunniiXD|2=I agree}}
+{{DiscordLog2|t= 00:31|1=GargameNga2025|2=idk how macleod would be}}
+{{DiscordLog2|t= 00:32|1=Eden342|2=if macleod gets a page than michael jackson is getting one too}}
+{{DiscordLog2|class=ping reply|1=FunniiXD|2=where did it start anyway}}
+{{DiscordLog2|t= 00:32|1=Heboyi|2=i think siiva is the first actual usage on a channel outside of ericarchive2 (duh)}}
+{{DiscordLog2|t= 00:32|1=Brunocoolgamers|2=macleod when you take away the uncanny song dj khaled what does he even do image}}
+{{DiscordLog2|t= 00:32|1=FunniiXD|2=I don't like the "ripping trend = not a meme" mindset if it's gonna reach siiva anyway wasn't smth like sorrizo a ripping trend before anyway}}
+{{DiscordLog2|t= 00:32|1=GargameNga2025|2=i kinda wish it stayed on ericarchive tbh LOL}}
+{{DiscordLog2|t= 00:33|1=GargameNga2025|2=i love that channel it deserved to keep that bit but it didnt so sad}}
+{{DiscordLog2|class=ping reply|1=FunniiXD|2=I don't like the "ripping trend = not a meme" mindset if it's gonna reach siiva anyway wasn't smth like sorrizo a ripping trend before anyway}}
+{{DiscordLog2|t= 00:34|1=ThisGreenDingo|2=Depends how much it impacts siiva. Gadget Room was a ttgd meme and a ripping trend but it was so impactful it also became a meme on siiva. Something like this feels too minor of an influence on the channel and the song has more extensive use on numerous fanchannels than any siiva association}}
+{{DiscordLog2|t= 00:35|1=ThisGreenDingo|2=I swear this had already been figured out could a reproposal not have waited another year or somein}}
+{{DiscordLog2|t= 00:35|1=Heboyi|2=it doesn't really have more extensive use on fan channels at all, it has like 5 uses on mysikt which is the most notable}}
+{{DiscordLog2|class=ping reply|1=Heboyi|2=it doesn't really have more extensive use on fan channels at all, it has like 5 uses on mysikt which is the most notable}}
+{{DiscordLog2|t= 00:35|1=ThisGreenDingo|2=What i meant by that is a small handful of rips for each fanchannel}}
+{{DiscordLog2|t= 00:35|1=GargameNga2025|2=new developments were made and the rejects i dont think had the best reasoning anyways so im okay with the reproposal}}
+{{DiscordLog2|t= 00:35|1=FunniiXD|2=dingo imma be real you're taking this too personally what did meatball parade do to hurt you}}
+{{DiscordLog2|class=ping reply|1=ThisGreenDingo|2=What i meant by that is a small handful of rips for each fanchannel}}
+{{DiscordLog2|t= 00:36|1=Heboyi|2=it doesn't really have that either}}
+{{DiscordLog2|t= 00:36|1=Brunocoolgamers|2=yeah it got quite a decent amount of rips since last time all in a small amount of time and i lowkey regret my vote on the first one}}
+{{DiscordLog2|class=ping reply|1=FunniiXD|2=dingo imma be real you're taking this too personally what did meatball parade do to hurt you}}
+{{DiscordLog2|t= 00:36|1=ThisGreenDingo|2=Oh sorry i actually dont care that deeply im just emotional rn i probably shouldnt be here im just trying to distract myself}}
+{{DiscordLog2|t= 00:36|1=FunniiXD|2=oh im sorry to hear apologies if this came off like a dig at you}}
+{{DiscordLog2|t= 00:37|1=CorbCreates|2=[[User:Keyher|Rudder Madness Day]] is your kevin macleod playlist complete?}}
+{{DiscordLog2|class=ping reply|1=CorbCreates|2=[[User:Keyher|Rudder Madness Day]] is your kevin macleod playlist complete?}}
+{{DiscordLog2|t= 00:37|1=CorbCreates|2=https://youtube.com/playlist?list=PLgYEwPsMPE-MCR_wKFuPrNVRir6rCnSuU}}
+{{DiscordLog2|class=ping reply|1=ThisGreenDingo|2=Oh sorry i actually dont care that deeply im just emotional rn i probably shouldnt be here im just trying to distract myself}}
+{{DiscordLog2|t= 00:38|1=ThisGreenDingo|2=like i still think we shouldn’t be so trigger happy on meme additions of edge cases like these because the effort really should go into improving existing pages and adding pages for more obvious cases}}
+{{DiscordLog2|class=ping reply|1=CorbCreates|2=[[User:Keyher|Rudder Madness Day]] is your kevin macleod playlist complete?}}
+{{DiscordLog2|t= 00:38|1=Keyher|2=hiii uhhh, afaik it is}}
+{{DiscordLog2|t= 00:38|1=Brunocoolgamers|2=i dont really think kevon macleod being or not a meme matter that much for this proposal i think meatball parade is clearly its own thing ethier way}}
+{{DiscordLog2|t= 00:38|1=FunniiXD|2=yeah}}
+{{DiscordLog2|t= 00:38|1=ThisGreenDingo|2=sorry if my choice of words makes it sound like this is ride or die its just mildly annoying ultimately}}
+{{DiscordLog2|t= 00:38|1=GargameNga2025|2=corb just wants to figure that out on his own}}
+{{DiscordLog2|class=ping reply|1=Keyher|2=hiii uhhh, afaik it is}}
+{{DiscordLog2|t= 00:39|1=CorbCreates|2=cool, i just dont really wanna need to make one for myself}}
+{{DiscordLog2|t= 00:39|1=FunniiXD|2=how often is meatball parade paired with other kevin stuff (I doubt much)}}
+{{DiscordLog2|t= 00:39|1=GargameNga2025|2=idek if ever}}
+{{DiscordLog2|t= 00:39|1=Eden342|2=it hasnt yet i think LOL}}
+{{DiscordLog2|t= 00:39|1=ThisGreenDingo|2=But yea i shouldnt be in meme proposals rn i just saw this and wanted to make a statement}}
+{{DiscordLog2|t= 00:40|1=Brunocoolgamers|2=someone is gonna drop the meatball parade sneaky snitch rip to change the narrative}}
+{{DiscordLog2|t= 00:40|1=Eden342|2=theyre gonna force multisource label onto meatball parade and call sneaky snitch a mp subsource}}
+{{DiscordLog2|class=ping reply|1=Brunocoolgamers|2=someone is gonna drop the meatball parade sneaky snitch rip to change the narrative}}
+{{DiscordLog2|t= 00:41|1=FunniiXD|2=that's one out of 25 or so by that point I think we'd be safe}}
+{{DiscordLog2|t= 00:45|1=FunniiXD|2=I like the contrast of the votes on my proposal to this one}}
+{{DiscordLog2|class=ping reply|1=FunniiXD|2=how often is meatball parade paired with other kevin stuff (I doubt much)}}
+{{DiscordLog2|t= 00:46|1=CorbCreates|2=If kevin stuff isnt paired with other kevin stuff, it will be very difficult to argue his music as a whole is a meme}}
+{{DiscordLog2|t= 00:50|1=Archimedes4047|2=Is it possible for the person proposing the meme to decide to close their proposal early, or do they have to wait for the proposal to close after the 7 days?}}
+{{DiscordLog2|t= 00:51|1=GargameNga2025|2=They can ask for it to be nulled or whatever}}
+{{DiscordLog2|t= 00:51|1=FunniiXD|2=I think they can close it if they regret or smth its happened a couple times}}
+{{DiscordLog2|class=ping reply|1=FunniiXD|2=how often is meatball parade paired with other kevin stuff (I doubt much)}}
+{{DiscordLog2|t= 00:53|1=Heboyi|2=twice but they're both outliers in that they're more typical melodyswaps instead of arrangements in the style of meatball parade.
+https://youtu.be/S3mQJ7wxNwo?si=IqsFk1wYWy-W-lFE
+https://youtu.be/1c-h1K9_HBI?si=IH1WXNaZYVscR464}}
+{{DiscordLog2|t= 03:02|1=CorbCreates|2=Macleod General:
+'16: 4 Times - 2 Memeworthy
+'17: 2 Times - 1 Memeworthy
+'18: 13 Times; 12 for UHC and Takeover - 1 Memeworthy
+'19: 5 Times - 2 Memeworthy
+'20: 7 Times - 3 Memeworthy
+'21: 10 Times - 7 Memeworthy
+'22: 37 Times; 8 Using S.A; 6 obv. MIBU - 20 Memeworthy
+'23: 24 Times; 5 Using S.A; 2 obv. MIBU - 18 Memeworthy
+'24: 23 Times; 2 Using S.A; 1 obv. MIBU - 16 Memeworthy
+'25: 9 Times - 8 Memeworthy
+Number of small rips featuring 2 KM songs: <s>5</s>''7'' (+ 2 more for Poem Panic rips referencing each other)
+
+Meatball Parade:
+'22: 11
+'23: 6
+'24: 4
+'25: 3
+Basically all are memeworthy, though only 2 feature other KM songs.
+
+Looking through these rips, there is an extremely clear uptick in Kevin MacLeod usage heading into 2022, that is significantly larger than only Mr. Incredible Becoming Uncanny. Despite the very clear lack of rips featuring multiple KM songs, it is very difficult to dismiss this large trend. Unsurprisingly, the Meatball Parade usage matches almost perfectly with the amount the rest of KM has gotten used.
+However, this usage must be weighed against how iconic Kevin MacLeod music is across the internet. Many of the rips featuring his songs are one-off references to various pieces of internet culture, like specific YouTubers or videos, or other memes entirely. If you take the known instances of these into account, along with excluding massive medleys, you get the right list of uses that are tied strongly to just KM.
+Looking at the amount of uses of Kevin MacLeod compared to his slowly declining popularity in the internet ever since 2015, it is very easy to see a trend of popularity isolated to specifically siivagunner that picked up just before the relevance of Mr. Incredible Becoming Uncanny, but continued to outlive it in relevancy for over 2 years and is only just now starting to slow down in usage.
+I will support the restructure of making Kevin Macleod the meme. [[File:Voting-restructure.svg|20px|link=]] If Meatball Parade starts to pick up separately from Macleod, then we can revisit the song being a meme.}}
+{{DiscordLog2|t= 03:27|1=GargameNga2025|2=i think this ignores the larger ripping context meatball parade lives in which makes the main idea just meatball pretty explicitly since the other kevin songs have no  greater ripping community presence outside of it and uncanny}}
+{{DiscordLog2|t= 03:52|1=TurretBot|2=whats the larger context}}
+{{DiscordLog2|class=ping reply|1=CorbCreates|2=Macleod General:
+'16: 4 Times - 2 Memeworthy
+'17: 2 Times - 1 Memeworthy
+'18: 13 Times; 12 for UHC and Takeover - 1 Memeworthy
+'19: 5 Times - 2 Memeworthy
+'20: 7 Times - 3 Memeworthy
+'21: 10 Times - 7 Memeworthy
+'22: 37 Times; 8 Using S.A; 6 obv. MIBU - 20 Memeworthy
+'23: 24 Times; 5 Using S.A; 2 obv. MIBU - 18 Memeworthy
+'24: 23 Times; 2 Using S.A; 1 obv. MIBU - 16 Memeworthy
+'25: 9 Times - 8 Memeworthy
+Number of small rips featuring 2 KM songs: <s>5</s>''7'' (+ 2 more for Poem Panic rips referencing each other)
+
+Meatball Parade:
+'22: 11
+'23: 6
+'24: 4
+'25: 3
+Basically all are memeworthy, though only 2 feature other KM songs.
+
+Looking through these rips, there is an extremely clear uptick in Kevin MacLeod usage heading into 2022, that is significantly larger than only Mr. Incredible Becoming Uncanny. Despite the very clear lack of rips featuring multiple KM songs, it is very difficult to dismiss this large trend. Unsurprisingly, the Meatball Parade usage matches almost perfectly with the amount the rest of KM has gotten used.
+However, this usage must be weighed against how iconic Kevin MacLeod music is across the internet. Many of the rips featuring his songs are one-off references to various pieces of internet culture, like specific YouTubers or videos, or other memes entirely. If you take the known instances of these into account, along with excluding massive medleys, you get the right list of uses that are tied strongly to just KM.
+Looking at the amount of uses of Kevin MacLeod compared to his slowly declining popularity in the internet ever since 2015, it is very easy to see a trend of popularity isolated to specifically siivagunner that picked up just before the relevance of Mr. Incredible Becoming Uncanny, but continued to outlive it in relevancy for over 2 years and is only just now starting to slow down in usage.
+I will support the restructure of making Kevin Macleod the meme. [[File:Voting-restructure.svg|20px|link=]] If Meatball Parade starts to pick up separately from Macleod, then we can revisit the song being a meme.}}
+{{DiscordLog2|t= 03:52|1=TurretBot|2=what is s.a 😭}}
+{{DiscordLog2|t= 03:53|1=GargameNga2025|2=sneaky adventure bruh}}
+{{DiscordLog2|t= 03:53|1=TurretBot|2=wow}}
+{{DiscordLog2|t= 03:53|1=CorbCreates|2=yeah, its the one used in the uncanny meme}}
+{{DiscordLog2|t= 03:53|1=GargameNga2025|2=this guy does NOT know mr incredible becoming uncanny fake memer ahh}}
+{{DiscordLog2|t= 03:54|1=CorbCreates|2=mb for not using the full name once}}
+{{DiscordLog2|t= 03:55|1=TurretBot|2=it seems weird to make a category for a kevin macleod trend that would also include a lot of rips not related to him as the main idea as you say}}
+{{DiscordLog2|t= 03:55|1=CorbCreates|2=yeah thats a fair assessment}}
+{{DiscordLog2|class=ping reply|1=TurretBot|2=whats the larger context}}
+{{DiscordLog2|t= 03:55|1=GargameNga2025|2=its just a funny flp arrangement thing that was used before siiva and pretty clearly just exists as fodder for that type of rip  it appeared in the old chica singing fusion collab on mysikt before siiva got to it and was prominent there at like the same time as siiva}}
+{{DiscordLog2|t= 03:56|1=TurretBot|2=meatball parade is the bad guy pixels meme}}
+{{DiscordLog2|t= 03:56|1=GargameNga2025|2=i dont think its connected to a larger kevin trend basically}}
+{{DiscordLog2|class=ping reply|1=CorbCreates|2=yeah thats a fair assessment}}
+{{DiscordLog2|t= 03:57|1=CorbCreates|2=quite a few are made in reference to Jerma rats, theres like 3 in 2020/2021 made in reference to Ceave Gaming, theres obv Mr. Incredible, and theres a bunch of miscellaneous references that deconfirm intentional ties to MacLeod. There is still notable usage outside of this but it obviously makes it weird to make a dedicated category}}
+{{DiscordLog2|t= 03:58|1=TurretBot|2=accordian to the data}}
+{{DiscordLog2|t= 03:59|1=CorbCreates|2=yah accordian to the data}}
+{{DiscordLog2|t= 03:59|1=TurretBot|2=memes: kevin macleod (excludes any usage tied to other media that used him) and meatball parade flp (excludes melody swap rips)}}
+{{DiscordLog2|t= 04:00|1=GargameNga2025|2=yesss dude}}
+{{DiscordLog2|t= 04:00|1=Brunocoolgamers|2=flps are probably a meme at this point}}
+{{DiscordLog2|class=ping reply|1=TurretBot|2=memes: kevin macleod (excludes any usage tied to other media that used him) and meatball parade flp (excludes melody swap rips)}}
+{{DiscordLog2|t= 04:01|1=TurretBot|2=[[File:Voting-restructure.svg|20px|link=]] 🔵}}
+{{DiscordLog2|t= 04:01|1=GargameNga2025|2=although i would argue the melodyswaps r just conveying the idea of the flp}}
+{{DiscordLog2|t= 04:01|1=TurretBot|2=its probably a coincidence}}
+{{DiscordLog2|class=ping reply|1=GargameNga2025|2=although i would argue the melodyswaps r just conveying the idea of the flp}}
+{{DiscordLog2|t= 04:01|1=Brunocoolgamers|2=yeah i agree with that making a category just for the flp is weird}}
+{{DiscordLog2|t= 04:02|1=Brunocoolgamers|2=what would you even call it meatball parade arragements}}
+{{DiscordLog2|t= 04:02|1=GargameNga2025|2=harlem shake will be 2 memes one is the pitch shift flp and one is the remake flp}}
+{{DiscordLog2|t= 04:02|1=Eden342|2=thats dumb}}
+{{DiscordLog2|class=ping reply|1=GargameNga2025|2=harlem shake will be 2 memes one is the pitch shift flp and one is the remake flp}}
+{{DiscordLog2|t= 04:02|1=Brunocoolgamers|2=wano needs this but thats besids the point}}
+{{DiscordLog2|t= 04:02|1=Eden342|2=not rlly}}
+{{DiscordLog2|t= 04:03|1=TurretBot|2=i agree}}
+{{DiscordLog2|t= 04:03|1=GargameNga2025|2=i would like that cuz theres like 8 melodyswaps and i wanna hear them}}
+{{DiscordLog2|t= 04:03|1=TurretBot|2=we can call the categories "good wano rips" and "bad wano rips"}}
+{{DiscordLog2|t= 04:03|1=GargameNga2025|2=LOL}}
+{{DiscordLog2|class=ping reply|1=Eden342|2=not rlly}}
+{{DiscordLog2|t= 04:04|1=Brunocoolgamers|2=For the record that message is an epic joke}}
+{{DiscordLog2|t= 04:05|1=TurretBot|2=not anymore}}
+{{DiscordLog2|class=ping reply|1=TurretBot|2=[[File:Voting-restructure.svg|20px|link=]] 🔵}}
+{{DiscordLog2|t= 04:05|1=Heboyi|2=thats ohiostructure bruh}}
+{{DiscordLog2|class=ping reply|1=GargameNga2025|2=i would like that cuz theres like 8 melodyswaps and i wanna hear them}}
+{{DiscordLog2|t= 04:05|1=Brunocoolgamers|2=https://youtu.be/WhJMJwpFRyQ?si=oPOiwvL35ZRDzYVr}}
+{{DiscordLog2|t= 04:06|1=Brunocoolgamers|2=Anyways making a differate category for flp arranges is dumb specially since the melodyswap didnt beacome a thing until after the flp era}}
+{{DiscordLog2|class=date-separator|t=July 23, 2025}}
+{{DiscordLog2|t= 08:03|1=GoldM|2=The intention is to reference Meatball Parade either way}}
+{{DiscordLog2|class=date-separator|t=July 24, 2025}}
+{{DiscordLog2|t= 16:32|1=Stump-7|2=[[File:Voting-oppose.svg|20px|link=]] i feel like the usage is too infrequent to warrant the meme status}}
+{{DiscordLog2|class=date-separator|t=July 25, 2025}}
+{{DiscordLog2|t= 13:49|1=Noescape000|2=[[File:Voting-support.svg|20px|link=]] If we can let stuff like Phonics Song in this should be fine as well}}
+{{DiscordLog2|t= 14:31|1=GargameNga2025|2=true}}
+{{DiscordLog2|class=date-separator|t=July 27, 2025}}
+{{DiscordLog2|class=ping reply|1=Heboyi|2=my current stance is support but imma wait until the discussion has run dry and a decision is practically already there to actually support it because Conflict of Interest}}
+{{DiscordLog2|t= 01:28|1=Heboyi|2=[[File:Voting-support.svg|20px|link=]] I'll support now}}
+{{DiscordLog2|class=date-separator|t=July 28, 2025}}
+{{DiscordLog2|t= 16:47|1=Arthur10123|2=[[File:Voting-support.svg|20px|link=]] notable enough on its own. I would like to consider MacLeod in general a meme, but I don't think it's quite strong enough right now}}
+{{DiscordLog2|class=date-separator|t=July 29, 2025}}
+{{DiscordLog2|t= 17:07|1=Archimedes4047|2=If this gets approved, I'll watch/listen to everything in the 3 kfad playlists (KFAD1, KFAD2, and fake KFAD2 playlists). I doubt it will, but if it somehow does, I'll do this. Also, I believe it's time to tally the votes.}}
+{{DiscordLog2|t= 17:12|1=Nuc1eusknight|2=wow it is}}
+{{DiscordLog2|class=ping reply|1=Nuc1eusknight|2=wow it is}}
+{{DiscordLog2|t= 17:32|1=Archimedes4047|2=Should we ping someone about it? Or just wait?}}
+{{DiscordLog2|t= 17:32|1=Nuc1eusknight|2=wait i say}}
+{{DiscordLog2|class=ping reply|1=Nuc1eusknight|2=wait i say}}
+{{DiscordLog2|t= 17:33|1=Archimedes4047|2=Alright}}
+{{DiscordLog2|t= 21:51|1=Archimedes4047|2=[[User:Eden342|sadredball]] [[User:Arthur10123|Arthur101 mas ele é intrigante ‼]] sorry for the pings, but it's time to tally the votes for this. (Idk why I pinged both of you, sorry)}}
+{{DiscordLog2|t= 21:51|1=Eden342|2=doing other wiki stuff atm sorry}}
+{{DiscordLog2|class=ping reply|1=Eden342|2=doing other wiki stuff atm sorry}}
+{{DiscordLog2|t= 21:52|1=Archimedes4047|2=Alright!}}
+{{DiscordLog2|class=date-separator|t=July 30, 2025}}
+{{DiscordLog2|t= 10:43|1=CorbCreates|2=If nobody has done it by the time I am done work and stuff in like 9-10 hours then sure}}
+{{DiscordLog2|class=ping reply|1=CorbCreates|2=If nobody has done it by the time I am done work and stuff in like 9-10 hours then sure}}
+{{DiscordLog2|t= 10:44|1=Archimedes4047|2=Alright!}}
+{{DiscordLog2|t= 02:07|1=CorbCreates|2='''[PROPOSAL END]'''
+[[File:Voting-support.svg|20px|link=]] SUPPORTS [[File:Voting-support.svg|20px|link=]]
+* Archimedes
+* Bruno
+* Eden
+* Funnii
+* Fezaki
+* Gleeberschnout
+* Heboyi
+* Arthur
+[[File:Voting-restructure.svg|20px|link=]] RESTRUCTURE A [[File:Voting-restructure.svg|20px|link=]]
+* HenriqueRick
+* Corb
+:upstructure: RESTRUCTURE B :upstructure:
+* Turretbot
+[[File:Voting-oppose.svg|20px|link=]] OPPOSE [[File:Voting-oppose.svg|20px|link=]]
+* ThisGreenDingo
+* Stump
+
+FINAL TALLY:
+8 Support (61.5%), 2 Restructure A (15.4%), 1 Restructure B (7.7%), 2 Oppose (15.4%)
+
+Proposal Rejected:
+We will not be creating any meme page or category for Kevin MacLeod.}}

--- a/__tests__/fixtures/tally_hall.txt
+++ b/__tests__/fixtures/tally_hall.txt
@@ -1,0 +1,42 @@
+<templatestyles src="Template:DiscordLog/styles.css"/>
+{{DiscordLog2|class=date-separator|t=December 11, 2024}}
+{{DiscordLog2|t= 03:44|1=Eden342|2=[[File:Voting-support.svg|20px|link=]] Tally Hall is a band. I believe that the band as a whole has made enough appearances throughout SiIvaGunner to be considered a meme.
+
+The band first started receiving frequent rips during Season 5, mainly "Ruler of Everything" as it was a popular meme at the time. Later that season, a full channel event would happen too.
+
+After this event, the band and some member's side projects (mainly Miracle Musical) would still continue to see frequent use in both solo rips and medley rips containing channel memes. Currently, counting any side-projects the members have done, there are 102 rips, 99 not counting album tracks (a little over 60 not counting these side-projects). This large amount makes the band feel more notable to the channel to me.
+
+The band was also referenced in the 7th anniversary collage, which already represents many other memes. It also has a joke game titled ''Banana'' that occasionally gets ripped to reference the song "Banana Man".
+[[User:Eden342/Tally Hall|Draft page I made for this topic, also includes a playlist of all rips featuring the band.]]}}
+{{DiscordLog2|t= 03:51|1=TurretBot|2={{t|f|Miracle Musical}} isn't a valid link}}
+{{DiscordLog2|t= 03:51|1=Eden342|2=forgot i added that let me remove it}}
+{{DiscordLog2|t= 03:52|1=Mick the Squirrel|2=is the ghost and molly magee supposed to be included in this as a side project}}
+{{DiscordLog2|t= 03:52|1=Eden342|2=yeah, just forgot to add those to my playlist}}
+{{DiscordLog2|t= 03:52|1=Mick the Squirrel|2=theres rips by individual beatles members that arent in the category, maybe we should stay consistent with this}}
+{{DiscordLog2|t= 03:53|1=Eden342|2=i would be fine with that}}
+{{DiscordLog2|t= 05:21|1=CorbCreates|2=I am struggling to figure out whether I should support this or not, because I know tally hall is used a lot, but its also simply due to the band being popular in smaller music circles like ours. Should any joke source that's generically popular be considered a meme? I wouldn't think so}}
+{{DiscordLog2|class=date-separator|t=December 12, 2024}}
+{{DiscordLog2|t= 12:22|1=Eden342|2=This is understandable and I do agree with that last part. It is mainly the pick up in usages in Season 5 (+ event) and the inclusion within the 7th anniversary collage that make me call this a meme even if it is a popular band.}}
+{{DiscordLog2|t= 12:22|1=Eden342|2=I kinda wanted to maybe restructure this so that only one of their songs is considered a meme, but I am not fully sure if that'd be allowed.}}
+{{DiscordLog2|class=date-separator|t=December 16, 2024}}
+{{DiscordLog2|t= 04:00|1=Mick the Squirrel|2=[[File:Voting-support.svg|20px|link=]] This seems harmless, high usage spread a few months prior and after the event seems to solidify it as something of value.}}
+{{DiscordLog2|t= 04:04|1=Notascryptic|2=[[File:Voting-support.svg|20px|link=]] Agree}}
+{{DiscordLog2|class=date-separator|t=December 17, 2024}}
+{{DiscordLog2|t= 14:19|1=Lollotheguy|2=[[File:Voting-support.svg|20px|link=]] I agree}}
+{{DiscordLog2|t= 14:27|1=CorbCreates|2=<s>I can't bring myself to support it for my reason above but I will vote neutral so if people want it, it can pass the number of votes requirement</s>}}
+{{DiscordLog2|t= 14:42|1=TurretBot|2=[[File:Voting-oppose.svg|20px|link=]] A minor bump in relevance that was not unique to siivagunner outside of one event doesn't justify a category catching strays indefinitely}}
+{{DiscordLog2|class=ping reply|1=CorbCreates|2=<s>I can't bring myself to support it for my reason above but I will vote neutral so if people want it, it can pass the number of votes requirement</s>}}
+{{DiscordLog2|t= 15:48|1=Mick the Squirrel|2=I should reiterate, within meme proposals, neutral votes only count for ''restructuring'' a proposal. If you do not have an opinion, this vote won't be counted.
+I decided on this because, in their default state, all neutral votes do is shift the vote percentage ''away'' from any true decision, and essentially count towards an opposition.
+True indifference should be communicated through the act of not voting at all.}}
+{{DiscordLog2|t= 15:49|1=CorbCreates|2=oh i forgot that, my bad}}
+{{DiscordLog2|t= 15:50|1=Mick the Squirrel|2=You're good, the way its designed is likely confusing in the first place.
+Changing the icon is one of my plans...}}
+{{DiscordLog2|t= 03:08|1=ThisGreenDingo|2=[[File:Voting-oppose.svg|20px|link=]] despite being in the 7th anniversary banner (a very good bit of evidence) i dont think theres a strong enough case, i dont think tally hall has been very impactful on siiva from personal experience}}
+{{DiscordLog2|class=date-separator|t=December 18, 2024}}
+{{DiscordLog2|t= 03:51|1=Eden342|2=[[User:Mick the Squirrel|Mick]] is it time}}
+{{DiscordLog2|class=ping reply|1=Eden342|2=[[User:Mick the Squirrel|Mick]] is it time}}
+{{DiscordLog2|t= 04:03|1=Mick the Squirrel|2=you want extension or no}}
+{{DiscordLog2|t= 04:03|1=Eden342|2=im fine with this not passing}}
+{{DiscordLog2|t= 04:04|1=Mick the Squirrel|2=Ok}}
+{{DiscordLog2|t= 04:05|1=Mick the Squirrel|2=Decision: '''Rejected''' (not enough votes)}}

--- a/__tests__/threshold.test.js
+++ b/__tests__/threshold.test.js
@@ -1,0 +1,94 @@
+import { evaluateThreshold } from '../votecount.js';
+
+describe('evaluateThreshold', () => {
+  describe('minimum voter requirement', () => {
+    test('returns null when fewer than 7 total voters', () => {
+      expect(evaluateThreshold(5, 1, 0).result).toBe('null');
+      expect(evaluateThreshold(3, 2, 1).result).toBe('null');
+      expect(evaluateThreshold(0, 0, 0).result).toBe('null');
+    });
+
+    test('does not return null with exactly 7 voters', () => {
+      expect(evaluateThreshold(7, 0, 0).result).not.toBe('null');
+    });
+  });
+
+  describe('support threshold (75%)', () => {
+    test('passes with exactly 75% support', () => {
+      // 9 support out of 12 = 75%
+      expect(evaluateThreshold(9, 3, 0).result).toBe('support');
+    });
+
+    test('passes with > 75% support', () => {
+      expect(evaluateThreshold(10, 2, 0).result).toBe('support');
+      expect(evaluateThreshold(7, 0, 0).result).toBe('support');
+    });
+
+    test('fails with < 75% support', () => {
+      // 8 support out of 12 = 66.7%
+      expect(evaluateThreshold(8, 4, 0).result).toBe('oppose');
+    });
+
+    test('100% support passes', () => {
+      expect(evaluateThreshold(15, 0, 0).result).toBe('support');
+    });
+  });
+
+  describe('restructure threshold (75%)', () => {
+    test('passes with 75% restructure', () => {
+      // 9 restructure out of 12 = 75%
+      expect(evaluateThreshold(0, 3, 9).result).toBe('restructure');
+    });
+
+    test('passes with > 75% restructure', () => {
+      expect(evaluateThreshold(1, 1, 8).result).toBe('restructure');
+    });
+
+    test('fails with < 75% restructure', () => {
+      // 5 restructure out of 10 = 50%
+      expect(evaluateThreshold(2, 3, 5).result).toBe('oppose');
+    });
+  });
+
+  describe('support and restructure are independent', () => {
+    test('support + restructure combined >= 75% but neither alone does not pass', () => {
+      // 5 support (50%) + 3 restructure (30%) + 2 oppose (20%) = 10 total
+      // Combined positive = 80%, but neither alone is 75%
+      expect(evaluateThreshold(5, 2, 3).result).toBe('oppose');
+    });
+
+    test('both over 75% is impossible (support wins)', () => {
+      // Can't have both >= 75% since they'd need > 150% total
+      // But if support is >= 75%, it wins regardless
+      expect(evaluateThreshold(8, 1, 1).result).toBe('support');
+    });
+  });
+
+  describe('oppose (fallthrough)', () => {
+    test('returns oppose when neither support nor restructure reaches 75%', () => {
+      expect(evaluateThreshold(5, 3, 2).result).toBe('oppose');
+    });
+
+    test('returns oppose with even split', () => {
+      expect(evaluateThreshold(4, 3, 3).result).toBe('oppose');
+    });
+  });
+
+  describe('reason messages', () => {
+    test('null reason mentions voter count', () => {
+      const { reason } = evaluateThreshold(3, 2, 1);
+      expect(reason).toContain('6/7');
+    });
+
+    test('support reason mentions percentage', () => {
+      const { reason } = evaluateThreshold(9, 3, 0);
+      expect(reason).toContain('75');
+    });
+
+    test('oppose reason mentions both percentages', () => {
+      const { reason } = evaluateThreshold(5, 3, 2);
+      expect(reason).toContain('Support');
+      expect(reason).toContain('Restructure');
+    });
+  });
+});

--- a/__tests__/votecount.test.js
+++ b/__tests__/votecount.test.js
@@ -1,0 +1,151 @@
+import { readFileSync } from 'fs';
+import { countVotes, parseWikitextLog, evaluateThreshold } from '../votecount.js';
+
+const fixturesDir = new URL('./fixtures/', import.meta.url).pathname;
+
+function loadFixture(name) {
+  return readFileSync(`${fixturesDir}${name}`, 'utf8');
+}
+
+describe('parseWikitextLog', () => {
+  test('parses Dougie log into messages', () => {
+    const wikitext = loadFixture('dougie.txt');
+    const messages = parseWikitextLog(wikitext);
+    expect(messages.length).toBeGreaterThan(0);
+    expect(messages[0].author.username).toBe('Nuc1eusknight');
+  });
+
+  test('skips ping reply and date-separator entries', () => {
+    const wikitext = loadFixture('dougie.txt');
+    const messages = parseWikitextLog(wikitext);
+    const hasReply = messages.some(m => m.content.includes('class=ping reply'));
+    expect(hasReply).toBe(false);
+  });
+});
+
+describe('Vote counting - Dougie (straightforward pass)', () => {
+  let result;
+
+  beforeAll(() => {
+    const wikitext = loadFixture('dougie.txt');
+    const messages = parseWikitextLog(wikitext);
+    result = countVotes(messages);
+  });
+
+  // Bot detects 12 support (TurretBot's text-based ":Support:" is not detected as emoji).
+  // Human tally was 13 support. The human would override TurretBot's count.
+  test('detects support count (best-effort, TurretBot text vote not detected)', () => {
+    expect(result.tally.support).toBe(12);
+  });
+
+  test('detects correct oppose count', () => {
+    expect(result.tally.oppose).toBe(2);
+  });
+
+  test('detects no restructure votes', () => {
+    expect(result.tally.restructure).toBe(0);
+  });
+
+  // TurretBot counted as neutral (not in total), GargameNga2025 ambiguous (not in total)
+  test('total is 14 (TurretBot neutral not counted)', () => {
+    expect(result.total).toBe(14);
+  });
+
+  test('GargameNga2025 strikethrough vote is NOT counted', () => {
+    const gargVoter = result.voters.support.find(v => v.username === 'GargameNga2025');
+    expect(gargVoter).toBeUndefined();
+    const gargOppose = result.voters.oppose.find(v => v.username === 'GargameNga2025');
+    expect(gargOppose).toBeUndefined();
+  });
+
+  test('GargameNga2025 is flagged as ambiguous', () => {
+    const ambig = result.ambiguous.find(a => a.username === 'GargameNga2025');
+    expect(ambig).toBeDefined();
+  });
+
+  test('Mick the Squirrel forwarded blockquote counts as oppose', () => {
+    const mick = result.voters.oppose.find(v => v.username === 'Mick the Squirrel');
+    expect(mick).toBeDefined();
+  });
+
+  test('TurretBot detected as neutral (text-based :Support: not detected)', () => {
+    expect(result.tally.neutral).toBe(1);
+    const turret = result.voters.neutral.find(v => v.username === 'TurretBot');
+    expect(turret).toBeDefined();
+  });
+
+  test('suggests support as outcome', () => {
+    expect(result.suggestedResult).toBe('support');
+  });
+});
+
+describe('Vote counting - Meatball Parade (restructure + rejected)', () => {
+  let result;
+
+  beforeAll(() => {
+    const wikitext = loadFixture('meatball_parade.txt');
+    const messages = parseWikitextLog(wikitext);
+    result = countVotes(messages);
+  });
+
+  test('detects support votes', () => {
+    expect(result.tally.support).toBe(8);
+  });
+
+  test('detects oppose votes', () => {
+    expect(result.tally.oppose).toBe(2);
+  });
+
+  test('detects restructure votes', () => {
+    // 2 restructure A + 1 restructure B = 3 total restructure
+    // But TurretBot's restructure was labeled "Restructure B" -- the bot counts all as one pool
+    expect(result.tally.restructure).toBeGreaterThanOrEqual(2);
+  });
+
+  test('total is 13', () => {
+    expect(result.total).toBe(13);
+  });
+
+  test('suggests oppose (no option reaches 75%)', () => {
+    expect(result.suggestedResult).toBe('oppose');
+  });
+
+  test('lists restructure voters for human grouping', () => {
+    expect(result.voters.restructure.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('Vote counting - Tally Hall (null, not enough votes)', () => {
+  let result;
+
+  beforeAll(() => {
+    const wikitext = loadFixture('tally_hall.txt');
+    const messages = parseWikitextLog(wikitext);
+    result = countVotes(messages);
+  });
+
+  test('detects support votes', () => {
+    expect(result.tally.support).toBe(4);
+  });
+
+  test('detects oppose votes', () => {
+    expect(result.tally.oppose).toBe(2);
+  });
+
+  test('total is 6 (below 7 minimum)', () => {
+    expect(result.total).toBe(6);
+  });
+
+  test('CorbCreates strikethrough neutral is NOT counted', () => {
+    const corb = result.voters.support.find(v => v.username === 'CorbCreates');
+    expect(corb).toBeUndefined();
+    const corbOppose = result.voters.oppose.find(v => v.username === 'CorbCreates');
+    expect(corbOppose).toBeUndefined();
+    const corbNeutral = result.voters.neutral?.find(v => v.username === 'CorbCreates');
+    expect(corbNeutral).toBeUndefined();
+  });
+
+  test('suggests null (not enough votes)', () => {
+    expect(result.suggestedResult).toBe('null');
+  });
+});

--- a/__tests__/wikiformat.test.js
+++ b/__tests__/wikiformat.test.js
@@ -1,0 +1,178 @@
+import {
+  toOrdinal,
+  logPageTitle,
+  archiveAnchor,
+  proposalsPageRow,
+  archiveEntry,
+  todoRow,
+  progressRow,
+} from '../wikiformat.js';
+
+describe('toOrdinal', () => {
+  test('1st through 4th', () => {
+    expect(toOrdinal(1)).toBe('1st');
+    expect(toOrdinal(2)).toBe('2nd');
+    expect(toOrdinal(3)).toBe('3rd');
+    expect(toOrdinal(4)).toBe('4th');
+  });
+
+  test('teens use th', () => {
+    expect(toOrdinal(11)).toBe('11th');
+    expect(toOrdinal(12)).toBe('12th');
+    expect(toOrdinal(13)).toBe('13th');
+  });
+
+  test('20s', () => {
+    expect(toOrdinal(20)).toBe('20th');
+    expect(toOrdinal(21)).toBe('21st');
+    expect(toOrdinal(22)).toBe('22nd');
+    expect(toOrdinal(23)).toBe('23rd');
+    expect(toOrdinal(24)).toBe('24th');
+  });
+
+  test('30 and 31', () => {
+    expect(toOrdinal(30)).toBe('30th');
+    expect(toOrdinal(31)).toBe('31st');
+  });
+
+  test('other values', () => {
+    expect(toOrdinal(5)).toBe('5th');
+    expect(toOrdinal(9)).toBe('9th');
+    expect(toOrdinal(10)).toBe('10th');
+    expect(toOrdinal(14)).toBe('14th');
+    expect(toOrdinal(19)).toBe('19th');
+    expect(toOrdinal(25)).toBe('25th');
+    expect(toOrdinal(29)).toBe('29th');
+  });
+});
+
+describe('logPageTitle', () => {
+  test('generates correct title', () => {
+    expect(logPageTitle(22, 'Meatball Parade'))
+      .toBe('SiIvaGunner Wiki:Meme discussion/Log/22nd: Meatball Parade');
+  });
+
+  test('handles quoted subjects', () => {
+    expect(logPageTitle(24, '"Weird Al" Yankovic'))
+      .toBe('SiIvaGunner Wiki:Meme discussion/Log/24th: "Weird Al" Yankovic');
+  });
+
+  test('handles 1st of month', () => {
+    expect(logPageTitle(1, 'Winter Wrap Up'))
+      .toBe('SiIvaGunner Wiki:Meme discussion/Log/1st: Winter Wrap Up');
+  });
+});
+
+describe('archiveAnchor', () => {
+  test('generates correct anchor', () => {
+    expect(archiveAnchor(14, 'Teach Me How to Dougie'))
+      .toBe('14th: Teach Me How to Dougie');
+  });
+});
+
+describe('proposalsPageRow', () => {
+  const baseOpts = {
+    subject: 'Teach Me How to Dougie',
+    day: 14,
+    proposer: 'Nuc1eusknight',
+    startDate: 'April 14, 2025',
+    endDate: 'April 21, 2025',
+  };
+
+  test('support row', () => {
+    const row = proposalsPageRow({ ...baseOpts, voteResult: 'support' });
+    expect(row).toContain('[[SiIvaGunner Wiki:Meme discussion/Log/14th: Teach Me How to Dougie|Teach Me How to Dougie]]');
+    expect(row).toContain('[[User:Nuc1eusknight|Nuc1eusknight]]');
+    expect(row).toContain('Voting-support.svg');
+    expect(row).toContain('Summary]]');
+  });
+
+  test('oppose row', () => {
+    const row = proposalsPageRow({ ...baseOpts, voteResult: 'oppose' });
+    expect(row).toContain('Voting-oppose.svg');
+  });
+
+  test('restructure row', () => {
+    const row = proposalsPageRow({ ...baseOpts, voteResult: 'restructure' });
+    expect(row).toContain('Voting-restructure.svg');
+  });
+
+  test('null row has no log link', () => {
+    const row = proposalsPageRow({ ...baseOpts, voteResult: 'null' });
+    expect(row).not.toContain('[[SiIvaGunner Wiki:Meme discussion/Log/');
+    expect(row).toContain('Null');
+  });
+});
+
+describe('archiveEntry', () => {
+  test('generates support entry with vote totals', () => {
+    const entry = archiveEntry({
+      subject: 'Teach Me How to Dougie',
+      day: 14,
+      summary: 'We will make a meme page and category for Teach Me How to Dougie.',
+      voteResult: 'support',
+      supportCount: 13,
+      opposeCount: 2,
+      restructureCount: 0,
+    });
+    expect(entry).toContain('#### 14th: **Teach Me How to Dougie**');
+    expect(entry).toContain('15 total');
+    expect(entry).toContain('support: 13');
+    expect(entry).toContain('oppose 2');
+  });
+
+  test('generates null entry', () => {
+    const entry = archiveEntry({
+      subject: 'Tally Hall',
+      day: 11,
+      summary: '',
+      voteResult: 'null',
+      supportCount: 4,
+      opposeCount: 2,
+      restructureCount: 0,
+    });
+    expect(entry).toContain('Not enough votes were cast');
+    expect(entry).toContain('6 total');
+  });
+
+  test('includes restructure in tally', () => {
+    const entry = archiveEntry({
+      subject: 'Meatball Parade',
+      day: 22,
+      summary: 'We will not make a meme page or category for Meatball Parade.',
+      voteResult: 'oppose',
+      supportCount: 8,
+      opposeCount: 2,
+      restructureCount: 3,
+    });
+    expect(entry).toContain('13 total');
+    expect(entry).toContain('restructure 3');
+  });
+});
+
+describe('todoRow', () => {
+  test('generates scaffold row', () => {
+    const row = todoRow({
+      subject: 'Teach Me How to Dougie',
+      day: 14,
+      summary: 'Create meme page for Teach Me How to Dougie',
+    });
+    expect(row).toContain('Archive#14th: Teach Me How to Dougie');
+    expect(row).toContain("''To be filled in by a wiki editor''");
+    expect(row).toContain('0%');
+  });
+});
+
+describe('progressRow', () => {
+  test('generates scaffold row', () => {
+    const row = progressRow({
+      subject: 'Teach Me How to Dougie',
+      day: 14,
+      summary: 'Create meme page for Teach Me How to Dougie',
+      currentDate: 'April 21, 2025',
+    });
+    expect(row).toContain('Archive#14th: Teach Me How to Dougie');
+    expect(row).toContain("'''Not done'''");
+    expect(row).toContain('April 21, 2025');
+  });
+});

--- a/__tests__/wikiformat.test.js
+++ b/__tests__/wikiformat.test.js
@@ -81,31 +81,38 @@ describe('proposalsPageRow', () => {
 
   test('support row', () => {
     const row = proposalsPageRow({ ...baseOpts, voteResult: 'support' });
-    expect(row).toContain('[[SiIvaGunner Wiki:Meme discussion/Log/14th: Teach Me How to Dougie|Teach Me How to Dougie]]');
-    expect(row).toContain('[[User:Nuc1eusknight|Nuc1eusknight]]');
-    expect(row).toContain('Voting-support.svg');
-    expect(row).toContain('Summary]]');
+    expect(row).toContain('|[[/Log/14th: Teach Me How to Dougie|Teach Me How to Dougie]]');
+    expect(row).toContain('|[[User:Nuc1eusknight|Nuc1eusknight]]');
+    expect(row).toContain('{{Icon|Voting-support.svg}}');
+    expect(row).toContain('[[/Archive#14th: Teach Me How to Dougie|Summary]]');
   });
 
   test('oppose row', () => {
     const row = proposalsPageRow({ ...baseOpts, voteResult: 'oppose' });
-    expect(row).toContain('Voting-oppose.svg');
+    expect(row).toContain('{{Icon|Voting-oppose.svg}}');
   });
 
   test('restructure row', () => {
     const row = proposalsPageRow({ ...baseOpts, voteResult: 'restructure' });
-    expect(row).toContain('Voting-restructure.svg');
+    expect(row).toContain('{{Icon|Voting-restructure.svg}}');
   });
 
   test('null row has no log link', () => {
     const row = proposalsPageRow({ ...baseOpts, voteResult: 'null' });
-    expect(row).not.toContain('[[SiIvaGunner Wiki:Meme discussion/Log/');
+    expect(row).not.toContain('[[/Log/');
     expect(row).toContain('Null');
+  });
+
+  test('each cell is on its own line', () => {
+    const row = proposalsPageRow({ ...baseOpts, voteResult: 'support' });
+    const lines = row.split('\n');
+    expect(lines).toHaveLength(5);
+    expect(lines.every(l => l.startsWith('|'))).toBe(true);
   });
 });
 
 describe('archiveEntry', () => {
-  test('generates support entry with vote totals', () => {
+  test('generates support entry with VoteSummary template', () => {
     const entry = archiveEntry({
       subject: 'Teach Me How to Dougie',
       day: 14,
@@ -115,10 +122,10 @@ describe('archiveEntry', () => {
       opposeCount: 2,
       restructureCount: 0,
     });
-    expect(entry).toContain('#### 14th: **Teach Me How to Dougie**');
-    expect(entry).toContain('15 total');
-    expect(entry).toContain('support: 13');
-    expect(entry).toContain('oppose 2');
+    expect(entry).toBe(
+      '==== 14th: Teach Me How to Dougie ====\n' +
+      '*We will make a meme page and category for Teach Me How to Dougie. {{VoteSummary|13|2|0}}'
+    );
   });
 
   test('generates null entry', () => {
@@ -131,11 +138,13 @@ describe('archiveEntry', () => {
       opposeCount: 2,
       restructureCount: 0,
     });
-    expect(entry).toContain('Not enough votes were cast');
-    expect(entry).toContain('6 total');
+    expect(entry).toBe(
+      '==== 11th: Tally Hall ====\n' +
+      '*Not enough votes (6/7) - proposal nulled.'
+    );
   });
 
-  test('includes restructure in tally', () => {
+  test('includes restructure in VoteSummary', () => {
     const entry = archiveEntry({
       subject: 'Meatball Parade',
       day: 22,
@@ -145,8 +154,7 @@ describe('archiveEntry', () => {
       opposeCount: 2,
       restructureCount: 3,
     });
-    expect(entry).toContain('13 total');
-    expect(entry).toContain('restructure 3');
+    expect(entry).toContain('{{VoteSummary|8|2|3}}');
   });
 });
 

--- a/__tests__/wikiformat.test.js
+++ b/__tests__/wikiformat.test.js
@@ -159,28 +159,32 @@ describe('archiveEntry', () => {
 });
 
 describe('todoRow', () => {
-  test('generates scaffold row', () => {
+  test('generates scaffold row with multiline cells', () => {
     const row = todoRow({
       subject: 'Teach Me How to Dougie',
       day: 14,
       summary: 'Create meme page for Teach Me How to Dougie',
     });
-    expect(row).toContain('Archive#14th: Teach Me How to Dougie');
-    expect(row).toContain("''To be filled in by a wiki editor''");
-    expect(row).toContain('0%');
+    expect(row).toContain('SiIvaGunner_Wiki:Meme_discussion/Archive#14th: Teach Me How to Dougie');
+    expect(row).toContain("# ''To be filled in by a wiki editor''");
+    expect(row).toContain('|0%');
+    const lines = row.split('\n');
+    expect(lines).toHaveLength(4);
   });
 });
 
 describe('progressRow', () => {
-  test('generates scaffold row', () => {
+  test('generates scaffold row with relative link and 5 columns', () => {
     const row = progressRow({
       subject: 'Teach Me How to Dougie',
       day: 14,
       summary: 'Create meme page for Teach Me How to Dougie',
       currentDate: 'April 21, 2025',
     });
-    expect(row).toContain('Archive#14th: Teach Me How to Dougie');
-    expect(row).toContain("'''Not done'''");
-    expect(row).toContain('April 21, 2025');
+    expect(row).toContain('[[../Archive#14th: Teach Me How to Dougie|April 21, 2025]]');
+    expect(row).toContain("| '''Not done'''");
+    expect(row).toContain('| April 21, 2025');
+    const lines = row.split('\n');
+    expect(lines).toHaveLength(5);
   });
 });

--- a/app.js
+++ b/app.js
@@ -21,6 +21,7 @@ import {
   addRoleToMember,
   getMemberInfo
 } from './archive.js';
+import { handleCloseCommand, handleCloseButton } from './close.js';
 
 // Create an express app
 const app = express();
@@ -379,6 +380,24 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async fun
       });
     }
 
+    if (name === 'close') {
+      // Check permissions
+      const allowedRoles = await getAllowedRoles();
+      const userRoles = req.body.member?.roles || [];
+      const hasPermission = allowedRoles.some(roleId => userRoles.includes(roleId));
+      if (!hasPermission) {
+        return res.send({
+          type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+          data: {
+            flags: InteractionResponseFlags.EPHEMERAL,
+            content: 'You do not have permission to close proposals. You need an allowed role.',
+          },
+        });
+      }
+
+      return handleCloseCommand(req, res);
+    }
+
     if (name === 'verified_members') {
       // Check if we have options
       if (!options || !options[0]) {
@@ -557,6 +576,21 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async fun
 
     console.error(`unknown command: ${name}`);
     return res.status(400).json({ error: 'unknown command' });
+  }
+
+  /**
+   * Handle message component interactions (button clicks)
+   */
+  if (type === InteractionType.MESSAGE_COMPONENT) {
+    const customId = req.body.data.custom_id;
+
+    // Check if this is a close confirm/cancel button
+    if (customId.startsWith('close_confirm_') || customId.startsWith('close_cancel_')) {
+      return handleCloseButton(req, res);
+    }
+
+    console.error('unknown component interaction:', customId);
+    return res.status(400).json({ error: 'unknown component interaction' });
   }
 
   console.error('unknown interaction type', type);

--- a/close.js
+++ b/close.js
@@ -1,0 +1,446 @@
+import { DiscordRequest } from './utils.js';
+import {
+  formatMessagesWithContext,
+  readDiscordThread,
+  getVerifiedMembers,
+} from './archive.js';
+import { countVotes, evaluateThreshold } from './votecount.js';
+import {
+  toOrdinal,
+  logPageTitle,
+  archiveAnchor,
+  proposalsPageRow,
+  archiveEntry,
+  todoRow,
+  progressRow,
+} from './wikiformat.js';
+import { wikiLogin, wikiReadPage, wikiEditPage, wikiAppendToPage } from './wiki.js';
+
+// In-memory store for pending close confirmations (keyed by interaction custom_id)
+const pendingCloses = new Map();
+
+/**
+ * Look up a Discord user ID in verified_members to get their wiki account name.
+ */
+function lookupWikiAccount(authors, discordUserId) {
+  const member = authors.find(a => a.memberId === discordUserId);
+  return member ? member.wikiAccount : null;
+}
+
+/**
+ * Get the option value from a slash command's options array.
+ */
+function getOption(options, name) {
+  const opt = options?.find(o => o.name === name);
+  return opt ? opt.value : undefined;
+}
+
+/**
+ * Extract the proposal subject from a thread name.
+ * Thread names often follow patterns like "Meatball Parade" or "22nd: Meatball Parade".
+ */
+function extractSubject(threadName) {
+  // Remove [CLOSED] prefix if present
+  let name = threadName.replace(/^\[CLOSED\]\s*/i, '');
+  // Remove ordinal prefix like "22nd: " if present
+  name = name.replace(/^\d+(?:st|nd|rd|th):\s*/, '');
+  return name.trim();
+}
+
+/**
+ * Handle the /close command. Returns the initial response object for Discord.
+ * The actual work happens asynchronously after the deferred response.
+ */
+export async function handleCloseCommand(req, res) {
+  const { data, channel } = req.body;
+  const { options } = data;
+  const { type: channelType, id: channelId } = channel;
+
+  // Must be used inside a thread
+  if (channelType !== 11) {
+    return res.send({
+      type: 4, // CHANNEL_MESSAGE_WITH_SOURCE
+      data: {
+        flags: 64, // EPHEMERAL
+        content: 'The `/close` command must be used inside a forum thread.',
+      },
+    });
+  }
+
+  // Send deferred response
+  await res.send({
+    type: 5, // DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+    data: { flags: 64 },
+  });
+
+  const webhookUrl = `https://discord.com/api/v10/webhooks/${process.env.APP_ID}/${req.body.token}`;
+
+  try {
+    // Parse options
+    const voteResult = getOption(options, 'vote_result');
+    const summary = getOption(options, 'summary');
+    const supportOverride = getOption(options, 'support_count');
+    const opposeOverride = getOption(options, 'oppose_count');
+    const restructureOverride = getOption(options, 'restructure_count');
+
+    // Get thread data
+    const threadRes = await fetch(`https://discord.com/api/v10/channels/${channelId}`, {
+      headers: { Authorization: `Bot ${process.env.DISCORD_TOKEN}` },
+    });
+    if (!threadRes.ok) throw new Error('Could not fetch thread data');
+    const threadData = await threadRes.json();
+
+    const subject = extractSubject(threadData.name);
+    const threadCreatorId = threadData.owner_id;
+    const startDate = new Date(threadData.thread_metadata?.create_timestamp || threadData.id);
+
+    // Read thread messages
+    const messages = await readDiscordThread(channelId);
+    const authors = await getVerifiedMembers();
+
+    // Count votes
+    const messagesOldestFirst = [...messages].reverse();
+    const voteData = countVotes(messagesOldestFirst);
+
+    // Apply overrides
+    const finalSupport = supportOverride ?? voteData.tally.support;
+    const finalOppose = opposeOverride ?? voteData.tally.oppose;
+    const finalRestructure = restructureOverride ?? voteData.tally.restructure;
+    const finalTotal = finalSupport + finalOppose + finalRestructure;
+
+    // Evaluate threshold
+    const threshold = evaluateThreshold(finalSupport, finalOppose, finalRestructure);
+
+    // Look up proposer's wiki account
+    const proposerWiki = lookupWikiAccount(authors, threadCreatorId);
+    const proposerDisplay = proposerWiki || `Unknown (Discord ID: ${threadCreatorId})`;
+
+    // Format dates
+    const day = startDate.getUTCDate();
+    const startDateStr = startDate.toLocaleDateString('en-US', {
+      month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC',
+    });
+    const endDateStr = new Date().toLocaleDateString('en-US', {
+      month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC',
+    });
+    const currentDateStr = endDateStr;
+
+    // Generate archive wikitext
+    const nonBotMessages = messagesOldestFirst.filter(m => !m.author.bot);
+    const archiveWikitext = `<templatestyles src="Template:DiscordLog/styles.css"/>\n` +
+      formatMessagesWithContext(nonBotMessages, authors);
+
+    // Build preview
+    let preview = '**Proposal Close Preview**\n\n';
+    preview += `**Subject:** ${subject}\n`;
+    preview += `**Proposer:** ${proposerDisplay}\n`;
+    preview += `**Start date:** ${startDateStr}\n`;
+    preview += `**End date:** ${endDateStr}\n`;
+    preview += `**Vote result:** ${voteResult}\n`;
+    preview += `**Summary:** ${summary}\n\n`;
+
+    preview += `**Vote Tally** (bot-detected → final):\n`;
+    preview += `  Support: ${voteData.tally.support}${supportOverride !== undefined ? ` → ${supportOverride}` : ''}\n`;
+    preview += `  Oppose: ${voteData.tally.oppose}${opposeOverride !== undefined ? ` → ${opposeOverride}` : ''}\n`;
+    preview += `  Restructure: ${voteData.tally.restructure}${restructureOverride !== undefined ? ` → ${restructureOverride}` : ''}\n`;
+    if (voteData.tally.neutral > 0) {
+      preview += `  Neutral: ${voteData.tally.neutral} (not counted toward total)\n`;
+    }
+    preview += `  **Total: ${finalTotal}**\n`;
+    preview += `  Bot suggestion: **${threshold.result}** (${threshold.reason})\n\n`;
+
+    if (voteData.ambiguous.length > 0) {
+      preview += `**⚠ Ambiguous voters** (crossed out with no replacement):\n`;
+      for (const a of voteData.ambiguous) {
+        preview += `  - ${a.username}\n`;
+      }
+      preview += '\n';
+    }
+
+    if (voteData.voters.restructure.length > 0) {
+      preview += `**Restructure voters** (human must group into options):\n`;
+      for (const v of voteData.voters.restructure) {
+        const snippet = v.messageContent.slice(0, 100).replace(/\n/g, ' ');
+        preview += `  - ${v.username}: ${snippet}...\n`;
+      }
+      preview += '\n';
+    }
+
+    if (!proposerWiki) {
+      preview += `**⚠ Warning:** Could not find wiki account for thread creator (${threadCreatorId}). The proposer column will show the Discord ID.\n\n`;
+    }
+
+    preview += '**Planned actions:**\n';
+    preview += `1. Rename thread to "[CLOSED] ${threadData.name}"\n`;
+    preview += `2. Lock thread\n`;
+    preview += `3. Create log page: \`${logPageTitle(day, subject)}\`\n`;
+    preview += `4. Update archive page\n`;
+    preview += `5. Update proposals page (Active → Ended)\n`;
+    if (voteResult === 'support' || voteResult === 'restructure') {
+      preview += `6. Create scaffold entry on to-do list\n`;
+      preview += `7. Create scaffold entry on progress page\n`;
+    }
+
+    // Store pending data
+    const confirmId = `close_confirm_${channelId}_${Date.now()}`;
+    const cancelId = `close_cancel_${channelId}_${Date.now()}`;
+
+    pendingCloses.set(confirmId, {
+      channelId,
+      threadData,
+      subject,
+      day,
+      proposer: proposerDisplay,
+      startDateStr,
+      endDateStr,
+      currentDateStr,
+      voteResult,
+      summary,
+      supportCount: finalSupport,
+      opposeCount: finalOppose,
+      restructureCount: finalRestructure,
+      archiveWikitext,
+      token: req.body.token,
+      cancelId,
+    });
+    pendingCloses.set(cancelId, { confirmId, type: 'cancel' });
+
+    // Auto-expire after 15 minutes
+    setTimeout(() => {
+      pendingCloses.delete(confirmId);
+      pendingCloses.delete(cancelId);
+    }, 15 * 60 * 1000);
+
+    // Send preview with buttons
+    await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: preview,
+        flags: 64,
+        components: [{
+          type: 1, // ACTION_ROW
+          components: [
+            {
+              type: 2, // BUTTON
+              style: 3, // SUCCESS (green)
+              label: 'Confirm',
+              custom_id: confirmId,
+            },
+            {
+              type: 2,
+              style: 4, // DANGER (red)
+              label: 'Cancel',
+              custom_id: cancelId,
+            },
+          ],
+        }],
+      }),
+    });
+  } catch (error) {
+    console.error('Error in /close command:', error);
+    await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: `Error: ${error.message}`,
+        flags: 64,
+      }),
+    });
+  }
+}
+
+/**
+ * Handle a button interaction for close confirm/cancel.
+ * @returns {boolean} true if the interaction was handled, false if not a close button
+ */
+export async function handleCloseButton(req, res) {
+  const customId = req.body.data.custom_id;
+  const pending = pendingCloses.get(customId);
+
+  if (!pending) return false;
+
+  if (pending.type === 'cancel') {
+    // Cancel
+    pendingCloses.delete(pending.confirmId);
+    pendingCloses.delete(customId);
+    return res.send({
+      type: 7, // UPDATE_MESSAGE
+      data: {
+        content: 'Close operation cancelled.',
+        components: [],
+        flags: 64,
+      },
+    });
+  }
+
+  // Confirm -- execute all changes
+  const data = pending;
+  pendingCloses.delete(customId);
+  pendingCloses.delete(data.cancelId);
+
+  // Acknowledge immediately with deferred update
+  await res.send({
+    type: 6, // DEFERRED_UPDATE_MESSAGE
+  });
+
+  const webhookUrl = `https://discord.com/api/v10/webhooks/${process.env.APP_ID}/${req.body.token}`;
+
+  try {
+    const results = [];
+
+    // 1. Rename thread
+    try {
+      const newName = `[CLOSED] ${data.threadData.name}`.slice(0, 100);
+      await DiscordRequest(`channels/${data.channelId}`, {
+        method: 'PATCH',
+        body: { name: newName },
+      });
+      results.push('Thread renamed');
+    } catch (e) {
+      results.push(`Thread rename failed: ${e.message}`);
+    }
+
+    // 2. Lock thread
+    try {
+      await DiscordRequest(`channels/${data.channelId}`, {
+        method: 'PATCH',
+        body: { locked: true },
+      });
+      results.push('Thread locked');
+    } catch (e) {
+      results.push(`Thread lock failed: ${e.message}`);
+    }
+
+    // 3. Wiki edits -- login first
+    try {
+      await wikiLogin();
+    } catch (e) {
+      results.push(`Wiki login failed: ${e.message}`);
+      await fetch(webhookUrl, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          content: `Discord actions done, but wiki login failed:\n${results.join('\n')}\nError: ${e.message}`,
+          components: [],
+        }),
+      });
+      return;
+    }
+
+    // 4. Create log page
+    try {
+      const logTitle = logPageTitle(data.day, data.subject);
+      await wikiEditPage(logTitle, data.archiveWikitext, `Creating log page for proposal: ${data.subject}`);
+      results.push(`Log page created: ${logTitle}`);
+    } catch (e) {
+      results.push(`Log page creation failed: ${e.message}`);
+    }
+
+    // 5. Update archive page
+    try {
+      const entry = archiveEntry({
+        subject: data.subject,
+        day: data.day,
+        summary: data.summary,
+        voteResult: data.voteResult,
+        supportCount: data.supportCount,
+        opposeCount: data.opposeCount,
+        restructureCount: data.restructureCount,
+      });
+      await wikiAppendToPage(
+        'SiIvaGunner Wiki:Meme discussion/Archive',
+        '\n\n' + entry,
+        `Adding archive entry for: ${data.subject}`,
+      );
+      results.push('Archive page updated');
+    } catch (e) {
+      results.push(`Archive update failed: ${e.message}`);
+    }
+
+    // 6. Update proposals page (Active → Ended)
+    try {
+      const row = proposalsPageRow({
+        subject: data.subject,
+        day: data.day,
+        proposer: data.proposer,
+        startDate: data.startDateStr,
+        endDate: data.endDateStr,
+        voteResult: data.voteResult,
+      });
+
+      const proposalsContent = await wikiReadPage('SiIvaGunner Wiki:Meme discussion');
+      if (proposalsContent) {
+        // Find the Ended table and append the row before the table's closing |}
+        // This is a best-effort approach -- the human can fix it if needed
+        const endedTablePattern = /(\{\|[^\n]*\n(?:.*\n)*?)((?=\|\}))/;
+        const updated = proposalsContent + '\n'; // fallback: append if pattern not found
+        // For now, append as a comment for human to place correctly
+        await wikiAppendToPage(
+          'SiIvaGunner Wiki:Meme discussion',
+          `\n<!-- Bot: New ended proposal row -->\n<!-- ${row} -->`,
+          `Closing proposal: ${data.subject} (${data.voteResult})`,
+        );
+        results.push('Proposals page updated (row appended as comment for human placement)');
+      }
+    } catch (e) {
+      results.push(`Proposals page update failed: ${e.message}`);
+    }
+
+    // 7. To-do and progress scaffolds (only for support/restructure)
+    if (data.voteResult === 'support' || data.voteResult === 'restructure') {
+      try {
+        const todo = todoRow({
+          subject: data.subject,
+          day: data.day,
+          summary: data.summary,
+        });
+        await wikiAppendToPage(
+          'SiIvaGunner Wiki:Meme discussion/Meme discussion to-do list',
+          `\n|-\n${todo}`,
+          `Adding to-do scaffold for: ${data.subject}`,
+        );
+        results.push('To-do list scaffold added');
+      } catch (e) {
+        results.push(`To-do scaffold failed: ${e.message}`);
+      }
+
+      try {
+        const progress = progressRow({
+          subject: data.subject,
+          day: data.day,
+          summary: data.summary,
+          currentDate: data.currentDateStr,
+        });
+        await wikiAppendToPage(
+          'SiIvaGunner Wiki:Meme discussion/Progress',
+          `\n|-\n${progress}`,
+          `Adding progress scaffold for: ${data.subject}`,
+        );
+        results.push('Progress page scaffold added');
+      } catch (e) {
+        results.push(`Progress scaffold failed: ${e.message}`);
+      }
+    }
+
+    // Send final summary
+    await fetch(webhookUrl, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: `**Proposal closed successfully.**\n\n${results.map(r => `• ${r}`).join('\n')}`,
+        components: [],
+      }),
+    });
+  } catch (error) {
+    console.error('Error executing close:', error);
+    await fetch(webhookUrl, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: `Error executing close: ${error.message}`,
+        components: [],
+      }),
+    });
+  }
+}

--- a/close.js
+++ b/close.js
@@ -138,9 +138,12 @@ async function processClose({ options, channelId, token, webhookUrl }) {
   const day = startDate.getUTCDate();
   const now = new Date();
   const shortDate = (d) => `${d.getUTCMonth() + 1}/${d.getUTCDate()}/${d.getUTCFullYear()}`;
+  const longDate = (d) => d.toLocaleDateString('en-US', {
+    month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC',
+  });
   const startDateStr = shortDate(startDate);
   const endDateStr = shortDate(now);
-  const currentDateStr = endDateStr;
+  const currentDateLong = longDate(now);
 
   // Generate archive wikitext
   const nonBotMessages = messagesOldestFirst.filter(m => !m.author.bot);
@@ -210,7 +213,7 @@ async function processClose({ options, channelId, token, webhookUrl }) {
     proposer: proposerDisplay,
     startDateStr,
     endDateStr,
-    currentDateStr,
+    currentDateLong,
     voteResult,
     summary,
     supportCount: finalSupport,
@@ -264,7 +267,16 @@ export async function handleCloseButton(req, res) {
   const customId = req.body.data.custom_id;
   const pending = pendingCloses.get(customId);
 
-  if (!pending) return false;
+  if (!pending) {
+    return res.send({
+      type: 7, // UPDATE_MESSAGE
+      data: {
+        content: 'This close operation has already been processed or expired.',
+        components: [],
+        flags: 64,
+      },
+    });
+  }
 
   if (pending.type === 'cancel') {
     // Cancel
@@ -285,184 +297,216 @@ export async function handleCloseButton(req, res) {
   pendingCloses.delete(customId);
   pendingCloses.delete(data.cancelId);
 
-  // Acknowledge immediately with deferred update
-  await res.send({
-    type: 6, // DEFERRED_UPDATE_MESSAGE
+  // Immediately update the message to show processing state
+  res.send({
+    type: 7, // UPDATE_MESSAGE
+    data: {
+      content: '**Processing proposal close...**',
+      components: [],
+      flags: 64,
+    },
   });
 
-  const webhookUrl = `https://discord.com/api/v10/webhooks/${process.env.APP_ID}/${req.body.token}/messages/@original`;
+  // Do heavy work in a detached promise so Express returns immediately
+  const followupUrl = `https://discord.com/api/v10/webhooks/${process.env.APP_ID}/${req.body.token}`;
 
-  try {
-    const results = [];
-
-    // 1. Rename thread
-    try {
-      const newName = `[CLOSED] ${data.threadData.name}`.slice(0, 100);
-      await DiscordRequest(`channels/${data.channelId}`, {
-        method: 'PATCH',
-        body: { name: newName },
-      });
-      results.push('Thread renamed');
-    } catch (e) {
-      results.push(`Thread rename failed: ${e.message}`);
-    }
-
-    // 2. Lock thread
-    try {
-      await DiscordRequest(`channels/${data.channelId}`, {
-        method: 'PATCH',
-        body: { locked: true },
-      });
-      results.push('Thread locked');
-    } catch (e) {
-      results.push(`Thread lock failed: ${e.message}`);
-    }
-
-    // 3. Wiki edits -- login first
-    try {
-      await wikiLogin();
-    } catch (e) {
-      results.push(`Wiki login failed: ${e.message}`);
-      await fetch(webhookUrl, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          content: `**Proposal close partially failed.**\n\n${results.map(r => `• ${r}`).join('\n')}`,
-          components: [],
-        }),
-      });
-      return;
-    }
-
-    const wikiBase = process.env.WIKI_API_URL.replace('/w/api.php', '/wiki/');
-    const wikiLink = (title) => `${wikiBase}${encodeURIComponent(title).replace(/%2F/g, '/').replace(/%3A/g, ':')}`;
-
-    // 4. Create log page
-    try {
-      const logTitle = logPageTitle(data.day, data.subject);
-      await wikiEditPage(logTitle, data.archiveWikitext, `Creating log page for proposal: ${data.subject}`);
-      results.push(`[Log page created](${wikiLink(logTitle)})`);
-    } catch (e) {
-      results.push(`Log page creation failed: ${e.message}`);
-    }
-
-    // 5. Update archive page
-    try {
-      const entry = archiveEntry({
-        subject: data.subject,
-        day: data.day,
-        summary: data.summary,
-        voteResult: data.voteResult,
-        supportCount: data.supportCount,
-        opposeCount: data.opposeCount,
-        restructureCount: data.restructureCount,
-      });
-      const archiveTitle = 'SiIvaGunner Wiki:Meme discussion/Archive';
-      await wikiAppendToPage(
-        archiveTitle,
-        '\n\n' + entry,
-        `Adding archive entry for: ${data.subject}`,
-      );
-      const anchor = archiveAnchor(data.day, data.subject);
-      results.push(`[Archive page updated](${wikiLink(archiveTitle)}#${encodeURIComponent(anchor)})`);
-    } catch (e) {
-      results.push(`Archive update failed: ${e.message}`);
-    }
-
-    // 6. Update proposals page (Active → Ended)
-    try {
-      const row = proposalsPageRow({
-        subject: data.subject,
-        day: data.day,
-        proposer: data.proposer,
-        startDate: data.startDateStr,
-        endDate: data.endDateStr,
-        voteResult: data.voteResult,
-      });
-
-      const proposalsContent = await wikiReadPage('SiIvaGunner Wiki:Meme discussion');
-      if (proposalsContent) {
-        const marker = '<!--New row goes here-->';
-        const markerIndex = proposalsContent.indexOf(marker);
-
-        if (markerIndex !== -1) {
-          const newContent = proposalsContent.slice(0, markerIndex)
-            + `|-\n${row}\n${marker}`
-            + proposalsContent.slice(markerIndex + marker.length);
-
-          await wikiEditPage(
-            'SiIvaGunner Wiki:Meme discussion',
-            newContent,
-            `Closing proposal: ${data.subject} (${data.voteResult})`,
-          );
-          results.push(`[Proposals page updated](${wikiLink('SiIvaGunner Wiki:Meme discussion')})`);
-        } else {
-          await wikiAppendToPage(
-            'SiIvaGunner Wiki:Meme discussion',
-            `\n|-\n${row}`,
-            `Closing proposal: ${data.subject} (${data.voteResult})`,
-          );
-          results.push(`[Proposals page updated](${wikiLink('SiIvaGunner Wiki:Meme discussion')}) (marker not found, row appended)`);
-        }
-      }
-    } catch (e) {
-      results.push(`Proposals page update failed: ${e.message}`);
-    }
-
-    // 7. To-do and progress scaffolds (only for support/restructure)
-    if (data.voteResult === 'support' || data.voteResult === 'restructure') {
-      try {
-        const todo = todoRow({
-          subject: data.subject,
-          day: data.day,
-          summary: data.summary,
-        });
-        await wikiAppendToPage(
-          'SiIvaGunner Wiki:Meme discussion/Meme discussion to-do list',
-          `\n|-\n${todo}`,
-          `Adding to-do scaffold for: ${data.subject}`,
-        );
-        results.push(`[To-do list scaffold added](${wikiLink('SiIvaGunner Wiki:Meme discussion/Meme discussion to-do list')})`);
-      } catch (e) {
-        results.push(`To-do scaffold failed: ${e.message}`);
-      }
-
-      try {
-        const progress = progressRow({
-          subject: data.subject,
-          day: data.day,
-          summary: data.summary,
-          currentDate: data.currentDateStr,
-        });
-        await wikiAppendToPage(
-          'SiIvaGunner Wiki:Meme discussion/Progress',
-          `\n|-\n${progress}`,
-          `Adding progress scaffold for: ${data.subject}`,
-        );
-        results.push(`[Progress page scaffold added](${wikiLink('SiIvaGunner Wiki:Meme discussion/Progress')})`);
-      } catch (e) {
-        results.push(`Progress scaffold failed: ${e.message}`);
-      }
-    }
-
-    // Send final summary
-    await fetch(webhookUrl, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        content: `**Proposal closed successfully.**\n\n${results.map(r => `• ${r}`).join('\n')}`,
-        components: [],
-      }),
-    });
-  } catch (error) {
+  executeClose(data, followupUrl).catch(error => {
     console.error('Error executing close:', error);
-    await fetch(webhookUrl, {
-      method: 'PATCH',
+    fetch(followupUrl, {
+      method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         content: `Error executing close: ${error.message}`,
-        components: [],
+        flags: 64,
+      }),
+    }).catch(e => console.error('Failed to send error follow-up:', e));
+  });
+}
+
+/**
+ * Execute all close actions (Discord + Wiki) and send a follow-up with results.
+ */
+async function executeClose(data, followupUrl) {
+  const results = [];
+
+  // 1. Rename thread
+  try {
+    const newName = `[CLOSED] ${data.threadData.name}`.slice(0, 100);
+    await DiscordRequest(`channels/${data.channelId}`, {
+      method: 'PATCH',
+      body: { name: newName },
+    });
+    results.push('Thread renamed');
+  } catch (e) {
+    results.push(`Thread rename failed: ${e.message}`);
+  }
+
+  // 2. Lock thread
+  try {
+    await DiscordRequest(`channels/${data.channelId}`, {
+      method: 'PATCH',
+      body: { locked: true },
+    });
+    results.push('Thread locked');
+  } catch (e) {
+    results.push(`Thread lock failed: ${e.message}`);
+  }
+
+  // 3. Wiki edits -- login first
+  try {
+    await wikiLogin();
+  } catch (e) {
+    results.push(`Wiki login failed: ${e.message}`);
+    await fetch(followupUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: `**Proposal close partially failed.**\n\n${results.map(r => `• ${r}`).join('\n')}`,
+        flags: 64,
       }),
     });
+    return;
+  }
+
+  const wikiBase = process.env.WIKI_API_URL.replace('/w/api.php', '/wiki/');
+  const wikiLink = (title) => `${wikiBase}${encodeURIComponent(title).replace(/%2F/g, '/').replace(/%3A/g, ':')}`;
+
+  // 4. Create log page
+  try {
+    const logTitle = logPageTitle(data.day, data.subject);
+    await wikiEditPage(logTitle, data.archiveWikitext, `Creating log page for proposal: ${data.subject}`);
+    results.push(`[Log page created](${wikiLink(logTitle)})`);
+  } catch (e) {
+    results.push(`Log page creation failed: ${e.message}`);
+  }
+
+  // 5. Update archive page
+  try {
+    const entry = archiveEntry({
+      subject: data.subject,
+      day: data.day,
+      summary: data.summary,
+      voteResult: data.voteResult,
+      supportCount: data.supportCount,
+      opposeCount: data.opposeCount,
+      restructureCount: data.restructureCount,
+    });
+    const archiveTitle = 'SiIvaGunner Wiki:Meme discussion/Archive';
+    await wikiAppendToPage(
+      archiveTitle,
+      '\n\n' + entry,
+      `Adding archive entry for: ${data.subject}`,
+    );
+    const anchor = archiveAnchor(data.day, data.subject);
+    results.push(`[Archive page updated](${wikiLink(archiveTitle)}#${encodeURIComponent(anchor)})`);
+  } catch (e) {
+    results.push(`Archive update failed: ${e.message}`);
+  }
+
+  // 6. Update proposals page (Active → Ended)
+  try {
+    const row = proposalsPageRow({
+      subject: data.subject,
+      day: data.day,
+      proposer: data.proposer,
+      startDate: data.startDateStr,
+      endDate: data.endDateStr,
+      voteResult: data.voteResult,
+    });
+
+    const proposalsContent = await wikiReadPage('SiIvaGunner Wiki:Meme discussion');
+    if (proposalsContent) {
+      const marker = '<!--New row goes here-->';
+      const markerIndex = proposalsContent.indexOf(marker);
+
+      if (markerIndex !== -1) {
+        const newContent = proposalsContent.slice(0, markerIndex)
+          + `|-\n${row}\n${marker}`
+          + proposalsContent.slice(markerIndex + marker.length);
+
+        await wikiEditPage(
+          'SiIvaGunner Wiki:Meme discussion',
+          newContent,
+          `Closing proposal: ${data.subject} (${data.voteResult})`,
+        );
+        results.push(`[Proposals page updated](${wikiLink('SiIvaGunner Wiki:Meme discussion')})`);
+      } else {
+        await wikiAppendToPage(
+          'SiIvaGunner Wiki:Meme discussion',
+          `\n|-\n${row}`,
+          `Closing proposal: ${data.subject} (${data.voteResult})`,
+        );
+        results.push(`[Proposals page updated](${wikiLink('SiIvaGunner Wiki:Meme discussion')}) (marker not found, row appended)`);
+      }
+    }
+  } catch (e) {
+    results.push(`Proposals page update failed: ${e.message}`);
+  }
+
+  // 7. To-do and progress scaffolds (only for support/restructure)
+  if (data.voteResult === 'support' || data.voteResult === 'restructure') {
+    try {
+      const todo = todoRow({
+        subject: data.subject,
+        day: data.day,
+        summary: data.summary,
+      });
+      const todoTitle = 'SiIvaGunner Wiki:Meme discussion/Meme discussion to-do list';
+      const todoContent = await wikiReadPage(todoTitle);
+      const todoMarker = '<!-- Scaffolding';
+
+      if (todoContent && todoContent.includes(todoMarker)) {
+        const idx = todoContent.indexOf(todoMarker);
+        const newContent = todoContent.slice(0, idx)
+          + `|-\n${todo}\n${todoMarker}`
+          + todoContent.slice(idx + todoMarker.length);
+        await wikiEditPage(todoTitle, newContent, `Adding to-do scaffold for: ${data.subject}`);
+        results.push(`[To-do list scaffold added](${wikiLink(todoTitle)})`);
+      } else {
+        await wikiAppendToPage(todoTitle, `\n|-\n${todo}`, `Adding to-do scaffold for: ${data.subject}`);
+        results.push(`[To-do list scaffold added](${wikiLink(todoTitle)}) (marker not found, row appended)`);
+      }
+    } catch (e) {
+      results.push(`To-do scaffold failed: ${e.message}`);
+    }
+
+    try {
+      const progress = progressRow({
+        subject: data.subject,
+        day: data.day,
+        summary: data.summary,
+        currentDate: data.currentDateLong,
+      });
+      const progressTitle = 'SiIvaGunner Wiki:Meme discussion/Progress';
+      const progressContent = await wikiReadPage(progressTitle);
+      const progressMarker = '<!-- ...New entries...';
+
+      if (progressContent && progressContent.includes(progressMarker)) {
+        const idx = progressContent.indexOf(progressMarker);
+        const newContent = progressContent.slice(0, idx)
+          + `|-\n${progress}\n${progressMarker}`
+          + progressContent.slice(idx + progressMarker.length);
+        await wikiEditPage(progressTitle, newContent, `Adding progress scaffold for: ${data.subject}`);
+        results.push(`[Progress page scaffold added](${wikiLink(progressTitle)})`);
+      } else {
+        await wikiAppendToPage(progressTitle, `\n|-\n${progress}`, `Adding progress scaffold for: ${data.subject}`);
+        results.push(`[Progress page scaffold added](${wikiLink(progressTitle)}) (marker not found, row appended)`);
+      }
+    } catch (e) {
+      results.push(`Progress scaffold failed: ${e.message}`);
+    }
+  }
+
+  // Send results as a follow-up message
+  const resp = await fetch(followupUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      content: `**Proposal closed successfully.**\n\n${results.map(r => `• ${r}`).join('\n')}`,
+      flags: 64,
+    }),
+  });
+  if (!resp.ok) {
+    console.error('Failed to send close results:', resp.status, await resp.text());
   }
 }

--- a/close.js
+++ b/close.js
@@ -16,6 +16,22 @@ import {
 } from './wikiformat.js';
 import { wikiLogin, wikiReadPage, wikiEditPage, wikiAppendToPage } from './wiki.js';
 
+const TAG_NAME_MAP = {
+  support: 'approved',
+  oppose: 'rejected',
+  restructure: 'restructured',
+  null: 'not enough votes',
+  closed: 'closed',
+};
+
+const PREFIX_MAP = {
+  support: '[CLOSED]',
+  oppose: '[CLOSED]',
+  restructure: '[CLOSED]',
+  null: '[NULL]',
+  closed: '[CLOSED]',
+};
+
 // In-memory store for pending close confirmations (keyed by interaction custom_id)
 const pendingCloses = new Map();
 
@@ -190,15 +206,19 @@ async function processClose({ options, channelId, token, webhookUrl }) {
     preview += `**Warning:** Could not find wiki account for thread creator (${threadCreatorId}). The proposer column will show the Discord ID.\n\n`;
   }
 
+  const prefix = PREFIX_MAP[voteResult] || '[CLOSED]';
+  const tagName = TAG_NAME_MAP[voteResult] || voteResult;
+
   preview += '**Planned actions:**\n';
-  preview += `1. Rename thread to "[CLOSED] ${threadData.name}"\n`;
-  preview += `2. Lock thread\n`;
-  preview += `3. Create log page: \`${logPageTitle(day, subject)}\`\n`;
-  preview += `4. Update archive page\n`;
-  preview += `5. Update proposals page (Active → Ended)\n`;
+  preview += `1. Rename thread to "${prefix} ${threadData.name}"\n`;
+  preview += `2. Apply tag: **${tagName}**\n`;
+  preview += `3. Archive and lock thread\n`;
+  preview += `4. Create log page: \`${logPageTitle(day, subject)}\`\n`;
+  preview += `5. Update archive page\n`;
+  preview += `6. Update proposals page (Active → Ended)\n`;
   if (voteResult === 'support' || voteResult === 'restructure') {
-    preview += `6. Create scaffold entry on to-do list\n`;
-    preview += `7. Create scaffold entry on progress page\n`;
+    preview += `7. Create scaffold entry on to-do list\n`;
+    preview += `8. Create scaffold entry on progress page\n`;
   }
 
   // Store pending data
@@ -322,28 +342,6 @@ export async function handleCloseButton(req, res) {
     }).catch(e => console.error('Failed to send error follow-up:', e));
   });
 }
-
-/**
- * Map vote result to the expected forum tag name.
- */
-const TAG_NAME_MAP = {
-  support: 'approved',
-  oppose: 'rejected',
-  restructure: 'restructured',
-  null: 'not enough votes',
-  closed: 'closed',
-};
-
-/**
- * Map vote result to thread name prefix.
- */
-const PREFIX_MAP = {
-  support: '[CLOSED]',
-  oppose: '[CLOSED]',
-  restructure: '[CLOSED]',
-  null: '[NULL]',
-  closed: '[CLOSED]',
-};
 
 /**
  * Execute all close actions (Discord + Wiki) and send a follow-up with results.

--- a/close.js
+++ b/close.js
@@ -136,12 +136,10 @@ async function processClose({ options, channelId, token, webhookUrl }) {
 
   // Format dates
   const day = startDate.getUTCDate();
-  const startDateStr = startDate.toLocaleDateString('en-US', {
-    month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC',
-  });
-  const endDateStr = new Date().toLocaleDateString('en-US', {
-    month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC',
-  });
+  const now = new Date();
+  const shortDate = (d) => `${d.getUTCMonth() + 1}/${d.getUTCDate()}/${d.getUTCFullYear()}`;
+  const startDateStr = shortDate(startDate);
+  const endDateStr = shortDate(now);
   const currentDateStr = endDateStr;
 
   // Generate archive wikitext
@@ -336,11 +334,14 @@ export async function handleCloseButton(req, res) {
       return;
     }
 
+    const wikiBase = process.env.WIKI_API_URL.replace('/w/api.php', '/wiki/');
+    const wikiLink = (title) => `${wikiBase}${encodeURIComponent(title).replace(/%2F/g, '/').replace(/%3A/g, ':')}`;
+
     // 4. Create log page
     try {
       const logTitle = logPageTitle(data.day, data.subject);
       await wikiEditPage(logTitle, data.archiveWikitext, `Creating log page for proposal: ${data.subject}`);
-      results.push(`Log page created: ${logTitle}`);
+      results.push(`[Log page created](${wikiLink(logTitle)})`);
     } catch (e) {
       results.push(`Log page creation failed: ${e.message}`);
     }
@@ -356,12 +357,14 @@ export async function handleCloseButton(req, res) {
         opposeCount: data.opposeCount,
         restructureCount: data.restructureCount,
       });
+      const archiveTitle = 'SiIvaGunner Wiki:Meme discussion/Archive';
       await wikiAppendToPage(
-        'SiIvaGunner Wiki:Meme discussion/Archive',
+        archiveTitle,
         '\n\n' + entry,
         `Adding archive entry for: ${data.subject}`,
       );
-      results.push('Archive page updated');
+      const anchor = archiveAnchor(data.day, data.subject);
+      results.push(`[Archive page updated](${wikiLink(archiveTitle)}#${encodeURIComponent(anchor)})`);
     } catch (e) {
       results.push(`Archive update failed: ${e.message}`);
     }
@@ -379,17 +382,28 @@ export async function handleCloseButton(req, res) {
 
       const proposalsContent = await wikiReadPage('SiIvaGunner Wiki:Meme discussion');
       if (proposalsContent) {
-        // Find the Ended table and append the row before the table's closing |}
-        // This is a best-effort approach -- the human can fix it if needed
-        const endedTablePattern = /(\{\|[^\n]*\n(?:.*\n)*?)((?=\|\}))/;
-        const updated = proposalsContent + '\n'; // fallback: append if pattern not found
-        // For now, append as a comment for human to place correctly
-        await wikiAppendToPage(
-          'SiIvaGunner Wiki:Meme discussion',
-          `\n<!-- Bot: New ended proposal row -->\n<!-- ${row} -->`,
-          `Closing proposal: ${data.subject} (${data.voteResult})`,
-        );
-        results.push('Proposals page updated (row appended as comment for human placement)');
+        const marker = '<!--New row goes here-->';
+        const markerIndex = proposalsContent.indexOf(marker);
+
+        if (markerIndex !== -1) {
+          const newContent = proposalsContent.slice(0, markerIndex)
+            + `|-\n${row}\n${marker}`
+            + proposalsContent.slice(markerIndex + marker.length);
+
+          await wikiEditPage(
+            'SiIvaGunner Wiki:Meme discussion',
+            newContent,
+            `Closing proposal: ${data.subject} (${data.voteResult})`,
+          );
+          results.push(`[Proposals page updated](${wikiLink('SiIvaGunner Wiki:Meme discussion')})`);
+        } else {
+          await wikiAppendToPage(
+            'SiIvaGunner Wiki:Meme discussion',
+            `\n|-\n${row}`,
+            `Closing proposal: ${data.subject} (${data.voteResult})`,
+          );
+          results.push(`[Proposals page updated](${wikiLink('SiIvaGunner Wiki:Meme discussion')}) (marker not found, row appended)`);
+        }
       }
     } catch (e) {
       results.push(`Proposals page update failed: ${e.message}`);
@@ -408,7 +422,7 @@ export async function handleCloseButton(req, res) {
           `\n|-\n${todo}`,
           `Adding to-do scaffold for: ${data.subject}`,
         );
-        results.push('To-do list scaffold added');
+        results.push(`[To-do list scaffold added](${wikiLink('SiIvaGunner Wiki:Meme discussion/Meme discussion to-do list')})`);
       } catch (e) {
         results.push(`To-do scaffold failed: ${e.message}`);
       }
@@ -425,7 +439,7 @@ export async function handleCloseButton(req, res) {
           `\n|-\n${progress}`,
           `Adding progress scaffold for: ${data.subject}`,
         );
-        results.push('Progress page scaffold added');
+        results.push(`[Progress page scaffold added](${wikiLink('SiIvaGunner Wiki:Meme discussion/Progress')})`);
       } catch (e) {
         results.push(`Progress scaffold failed: ${e.message}`);
       }

--- a/close.js
+++ b/close.js
@@ -324,32 +324,73 @@ export async function handleCloseButton(req, res) {
 }
 
 /**
+ * Map vote result to the expected forum tag name.
+ */
+const TAG_NAME_MAP = {
+  support: 'approved',
+  oppose: 'rejected',
+  restructure: 'restructured',
+  null: 'not enough votes',
+  closed: 'closed',
+};
+
+/**
+ * Map vote result to thread name prefix.
+ */
+const PREFIX_MAP = {
+  support: '[CLOSED]',
+  oppose: '[CLOSED]',
+  restructure: '[CLOSED]',
+  null: '[NULL]',
+  closed: '[CLOSED]',
+};
+
+/**
  * Execute all close actions (Discord + Wiki) and send a follow-up with results.
  */
 async function executeClose(data, followupUrl) {
   const results = [];
 
-  // 1. Rename thread
+  // 1. Fetch parent forum channel to get available tags
+  let tagId = null;
   try {
-    const newName = `[CLOSED] ${data.threadData.name}`.slice(0, 100);
-    await DiscordRequest(`channels/${data.channelId}`, {
-      method: 'PATCH',
-      body: { name: newName },
-    });
-    results.push('Thread renamed');
+    const parentId = data.threadData.parent_id;
+    const forumRes = await DiscordRequest(`channels/${parentId}`, { method: 'GET' });
+    const forumData = await forumRes.json();
+    const availableTags = forumData.available_tags || [];
+    const targetTagName = TAG_NAME_MAP[data.voteResult] || '';
+    const matchedTag = availableTags.find(
+      t => t.name.toLowerCase() === targetTagName.toLowerCase()
+    );
+    if (matchedTag) {
+      tagId = matchedTag.id;
+    } else {
+      results.push(`Tag "${targetTagName}" not found on forum (available: ${availableTags.map(t => t.name).join(', ')})`);
+    }
   } catch (e) {
-    results.push(`Thread rename failed: ${e.message}`);
+    results.push(`Failed to fetch forum tags: ${e.message}`);
   }
 
-  // 2. Lock thread
+  // 2. Rename, tag, archive, and lock thread in a single PATCH
   try {
+    const prefix = PREFIX_MAP[data.voteResult] || '[CLOSED]';
+    const newName = `${prefix} ${data.threadData.name}`.slice(0, 100);
+    const patchBody = {
+      name: newName,
+      archived: true,
+      locked: true,
+    };
+    if (tagId) {
+      patchBody.applied_tags = [tagId];
+    }
     await DiscordRequest(`channels/${data.channelId}`, {
       method: 'PATCH',
-      body: { locked: true },
+      body: patchBody,
     });
-    results.push('Thread locked');
+    const tagNote = tagId ? ', tagged' : '';
+    results.push(`Thread renamed, closed${tagNote}, and locked`);
   } catch (e) {
-    results.push(`Thread lock failed: ${e.message}`);
+    results.push(`Thread update failed: ${e.message}`);
   }
 
   // 3. Wiki edits -- login first

--- a/close.js
+++ b/close.js
@@ -48,13 +48,14 @@ function extractSubject(threadName) {
 }
 
 /**
- * Handle the /close command. Returns the initial response object for Discord.
- * The actual work happens asynchronously after the deferred response.
+ * Handle the /close command. Sends the deferred response immediately,
+ * then does all heavy work in a detached promise so Express returns right away.
  */
 export async function handleCloseCommand(req, res) {
   const { data, channel } = req.body;
   const { options } = data;
-  const { type: channelType, id: channelId } = channel;
+  const channelType = channel?.type;
+  const channelId = channel?.id;
 
   // Must be used inside a thread
   if (channelType !== 11) {
@@ -67,187 +68,194 @@ export async function handleCloseCommand(req, res) {
     });
   }
 
-  // Send deferred response
-  await res.send({
+  // Send deferred response immediately so Discord doesn't time out
+  res.send({
     type: 5, // DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
     data: { flags: 64 },
   });
 
-  const webhookUrl = `https://discord.com/api/v10/webhooks/${process.env.APP_ID}/${req.body.token}`;
+  // Do all heavy work in a detached promise
+  const token = req.body.token;
+  const webhookUrl = `https://discord.com/api/v10/webhooks/${process.env.APP_ID}/${token}`;
 
-  try {
-    // Parse options
-    const voteResult = getOption(options, 'vote_result');
-    const summary = getOption(options, 'summary');
-    const supportOverride = getOption(options, 'support_count');
-    const opposeOverride = getOption(options, 'oppose_count');
-    const restructureOverride = getOption(options, 'restructure_count');
-
-    // Get thread data
-    const threadRes = await fetch(`https://discord.com/api/v10/channels/${channelId}`, {
-      headers: { Authorization: `Bot ${process.env.DISCORD_TOKEN}` },
-    });
-    if (!threadRes.ok) throw new Error('Could not fetch thread data');
-    const threadData = await threadRes.json();
-
-    const subject = extractSubject(threadData.name);
-    const threadCreatorId = threadData.owner_id;
-    const startDate = new Date(threadData.thread_metadata?.create_timestamp || threadData.id);
-
-    // Read thread messages
-    const messages = await readDiscordThread(channelId);
-    const authors = await getVerifiedMembers();
-
-    // Count votes
-    const messagesOldestFirst = [...messages].reverse();
-    const voteData = countVotes(messagesOldestFirst);
-
-    // Apply overrides
-    const finalSupport = supportOverride ?? voteData.tally.support;
-    const finalOppose = opposeOverride ?? voteData.tally.oppose;
-    const finalRestructure = restructureOverride ?? voteData.tally.restructure;
-    const finalTotal = finalSupport + finalOppose + finalRestructure;
-
-    // Evaluate threshold
-    const threshold = evaluateThreshold(finalSupport, finalOppose, finalRestructure);
-
-    // Look up proposer's wiki account
-    const proposerWiki = lookupWikiAccount(authors, threadCreatorId);
-    const proposerDisplay = proposerWiki || `Unknown (Discord ID: ${threadCreatorId})`;
-
-    // Format dates
-    const day = startDate.getUTCDate();
-    const startDateStr = startDate.toLocaleDateString('en-US', {
-      month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC',
-    });
-    const endDateStr = new Date().toLocaleDateString('en-US', {
-      month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC',
-    });
-    const currentDateStr = endDateStr;
-
-    // Generate archive wikitext
-    const nonBotMessages = messagesOldestFirst.filter(m => !m.author.bot);
-    const archiveWikitext = `<templatestyles src="Template:DiscordLog/styles.css"/>\n` +
-      formatMessagesWithContext(nonBotMessages, authors);
-
-    // Build preview
-    let preview = '**Proposal Close Preview**\n\n';
-    preview += `**Subject:** ${subject}\n`;
-    preview += `**Proposer:** ${proposerDisplay}\n`;
-    preview += `**Start date:** ${startDateStr}\n`;
-    preview += `**End date:** ${endDateStr}\n`;
-    preview += `**Vote result:** ${voteResult}\n`;
-    preview += `**Summary:** ${summary}\n\n`;
-
-    preview += `**Vote Tally** (bot-detected → final):\n`;
-    preview += `  Support: ${voteData.tally.support}${supportOverride !== undefined ? ` → ${supportOverride}` : ''}\n`;
-    preview += `  Oppose: ${voteData.tally.oppose}${opposeOverride !== undefined ? ` → ${opposeOverride}` : ''}\n`;
-    preview += `  Restructure: ${voteData.tally.restructure}${restructureOverride !== undefined ? ` → ${restructureOverride}` : ''}\n`;
-    if (voteData.tally.neutral > 0) {
-      preview += `  Neutral: ${voteData.tally.neutral} (not counted toward total)\n`;
-    }
-    preview += `  **Total: ${finalTotal}**\n`;
-    preview += `  Bot suggestion: **${threshold.result}** (${threshold.reason})\n\n`;
-
-    if (voteData.ambiguous.length > 0) {
-      preview += `**⚠ Ambiguous voters** (crossed out with no replacement):\n`;
-      for (const a of voteData.ambiguous) {
-        preview += `  - ${a.username}\n`;
-      }
-      preview += '\n';
-    }
-
-    if (voteData.voters.restructure.length > 0) {
-      preview += `**Restructure voters** (human must group into options):\n`;
-      for (const v of voteData.voters.restructure) {
-        const snippet = v.messageContent.slice(0, 100).replace(/\n/g, ' ');
-        preview += `  - ${v.username}: ${snippet}...\n`;
-      }
-      preview += '\n';
-    }
-
-    if (!proposerWiki) {
-      preview += `**⚠ Warning:** Could not find wiki account for thread creator (${threadCreatorId}). The proposer column will show the Discord ID.\n\n`;
-    }
-
-    preview += '**Planned actions:**\n';
-    preview += `1. Rename thread to "[CLOSED] ${threadData.name}"\n`;
-    preview += `2. Lock thread\n`;
-    preview += `3. Create log page: \`${logPageTitle(day, subject)}\`\n`;
-    preview += `4. Update archive page\n`;
-    preview += `5. Update proposals page (Active → Ended)\n`;
-    if (voteResult === 'support' || voteResult === 'restructure') {
-      preview += `6. Create scaffold entry on to-do list\n`;
-      preview += `7. Create scaffold entry on progress page\n`;
-    }
-
-    // Store pending data
-    const confirmId = `close_confirm_${channelId}_${Date.now()}`;
-    const cancelId = `close_cancel_${channelId}_${Date.now()}`;
-
-    pendingCloses.set(confirmId, {
-      channelId,
-      threadData,
-      subject,
-      day,
-      proposer: proposerDisplay,
-      startDateStr,
-      endDateStr,
-      currentDateStr,
-      voteResult,
-      summary,
-      supportCount: finalSupport,
-      opposeCount: finalOppose,
-      restructureCount: finalRestructure,
-      archiveWikitext,
-      token: req.body.token,
-      cancelId,
-    });
-    pendingCloses.set(cancelId, { confirmId, type: 'cancel' });
-
-    // Auto-expire after 15 minutes
-    setTimeout(() => {
-      pendingCloses.delete(confirmId);
-      pendingCloses.delete(cancelId);
-    }, 15 * 60 * 1000);
-
-    // Send preview with buttons
-    await fetch(webhookUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        content: preview,
-        flags: 64,
-        components: [{
-          type: 1, // ACTION_ROW
-          components: [
-            {
-              type: 2, // BUTTON
-              style: 3, // SUCCESS (green)
-              label: 'Confirm',
-              custom_id: confirmId,
-            },
-            {
-              type: 2,
-              style: 4, // DANGER (red)
-              label: 'Cancel',
-              custom_id: cancelId,
-            },
-          ],
-        }],
-      }),
-    });
-  } catch (error) {
+  processClose({ options, channelId, token, webhookUrl }).catch(error => {
     console.error('Error in /close command:', error);
-    await fetch(webhookUrl, {
+    fetch(webhookUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         content: `Error: ${error.message}`,
         flags: 64,
       }),
-    });
+    }).catch(e => console.error('Failed to send error follow-up:', e));
+  });
+}
+
+/**
+ * The actual close processing logic, runs after the deferred response is sent.
+ */
+async function processClose({ options, channelId, token, webhookUrl }) {
+  // Parse options
+  const voteResult = getOption(options, 'vote_result');
+  const summary = getOption(options, 'summary');
+  const supportOverride = getOption(options, 'support_count');
+  const opposeOverride = getOption(options, 'oppose_count');
+  const restructureOverride = getOption(options, 'restructure_count');
+
+  // Get thread data
+  const threadRes = await fetch(`https://discord.com/api/v10/channels/${channelId}`, {
+    headers: { Authorization: `Bot ${process.env.DISCORD_TOKEN}` },
+  });
+  if (!threadRes.ok) throw new Error('Could not fetch thread data');
+  const threadData = await threadRes.json();
+
+  const subject = extractSubject(threadData.name);
+  const threadCreatorId = threadData.owner_id;
+  const startDate = new Date(threadData.thread_metadata?.create_timestamp || threadData.id);
+
+  // Read thread messages
+  const messages = await readDiscordThread(channelId);
+  const authors = await getVerifiedMembers();
+
+  // Count votes
+  const messagesOldestFirst = [...messages].reverse();
+  const voteData = countVotes(messagesOldestFirst);
+
+  // Apply overrides
+  const finalSupport = supportOverride ?? voteData.tally.support;
+  const finalOppose = opposeOverride ?? voteData.tally.oppose;
+  const finalRestructure = restructureOverride ?? voteData.tally.restructure;
+  const finalTotal = finalSupport + finalOppose + finalRestructure;
+
+  // Evaluate threshold
+  const threshold = evaluateThreshold(finalSupport, finalOppose, finalRestructure);
+
+  // Look up proposer's wiki account
+  const proposerWiki = lookupWikiAccount(authors, threadCreatorId);
+  const proposerDisplay = proposerWiki || `Unknown (Discord ID: ${threadCreatorId})`;
+
+  // Format dates
+  const day = startDate.getUTCDate();
+  const startDateStr = startDate.toLocaleDateString('en-US', {
+    month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC',
+  });
+  const endDateStr = new Date().toLocaleDateString('en-US', {
+    month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC',
+  });
+  const currentDateStr = endDateStr;
+
+  // Generate archive wikitext
+  const nonBotMessages = messagesOldestFirst.filter(m => !m.author.bot);
+  const archiveWikitext = `<templatestyles src="Template:DiscordLog/styles.css"/>\n` +
+    formatMessagesWithContext(nonBotMessages, authors);
+
+  // Build preview
+  let preview = '**Proposal Close Preview**\n\n';
+  preview += `**Subject:** ${subject}\n`;
+  preview += `**Proposer:** ${proposerDisplay}\n`;
+  preview += `**Start date:** ${startDateStr}\n`;
+  preview += `**End date:** ${endDateStr}\n`;
+  preview += `**Vote result:** ${voteResult}\n`;
+  preview += `**Summary:** ${summary}\n\n`;
+
+  preview += `**Vote Tally** (bot-detected → final):\n`;
+  preview += `  Support: ${voteData.tally.support}${supportOverride !== undefined ? ` → ${supportOverride}` : ''}\n`;
+  preview += `  Oppose: ${voteData.tally.oppose}${opposeOverride !== undefined ? ` → ${opposeOverride}` : ''}\n`;
+  preview += `  Restructure: ${voteData.tally.restructure}${restructureOverride !== undefined ? ` → ${restructureOverride}` : ''}\n`;
+  if (voteData.tally.neutral > 0) {
+    preview += `  Neutral: ${voteData.tally.neutral} (not counted toward total)\n`;
   }
+  preview += `  **Total: ${finalTotal}**\n`;
+  preview += `  Bot suggestion: **${threshold.result}** (${threshold.reason})\n\n`;
+
+  if (voteData.ambiguous.length > 0) {
+    preview += `**Ambiguous voters** (crossed out with no replacement):\n`;
+    for (const a of voteData.ambiguous) {
+      preview += `  - ${a.username}\n`;
+    }
+    preview += '\n';
+  }
+
+  if (voteData.voters.restructure.length > 0) {
+    preview += `**Restructure voters** (human must group into options):\n`;
+    for (const v of voteData.voters.restructure) {
+      const snippet = v.messageContent.slice(0, 100).replace(/\n/g, ' ');
+      preview += `  - ${v.username}: ${snippet}...\n`;
+    }
+    preview += '\n';
+  }
+
+  if (!proposerWiki) {
+    preview += `**Warning:** Could not find wiki account for thread creator (${threadCreatorId}). The proposer column will show the Discord ID.\n\n`;
+  }
+
+  preview += '**Planned actions:**\n';
+  preview += `1. Rename thread to "[CLOSED] ${threadData.name}"\n`;
+  preview += `2. Lock thread\n`;
+  preview += `3. Create log page: \`${logPageTitle(day, subject)}\`\n`;
+  preview += `4. Update archive page\n`;
+  preview += `5. Update proposals page (Active → Ended)\n`;
+  if (voteResult === 'support' || voteResult === 'restructure') {
+    preview += `6. Create scaffold entry on to-do list\n`;
+    preview += `7. Create scaffold entry on progress page\n`;
+  }
+
+  // Store pending data
+  const confirmId = `close_confirm_${channelId}_${Date.now()}`;
+  const cancelId = `close_cancel_${channelId}_${Date.now()}`;
+
+  pendingCloses.set(confirmId, {
+    channelId,
+    threadData,
+    subject,
+    day,
+    proposer: proposerDisplay,
+    startDateStr,
+    endDateStr,
+    currentDateStr,
+    voteResult,
+    summary,
+    supportCount: finalSupport,
+    opposeCount: finalOppose,
+    restructureCount: finalRestructure,
+    archiveWikitext,
+    token,
+    cancelId,
+  });
+  pendingCloses.set(cancelId, { confirmId, type: 'cancel' });
+
+  // Auto-expire after 15 minutes
+  setTimeout(() => {
+    pendingCloses.delete(confirmId);
+    pendingCloses.delete(cancelId);
+  }, 15 * 60 * 1000);
+
+  // Send preview with buttons
+  await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      content: preview,
+      flags: 64,
+      components: [{
+        type: 1, // ACTION_ROW
+        components: [
+          {
+            type: 2, // BUTTON
+            style: 3, // SUCCESS (green)
+            label: 'Confirm',
+            custom_id: confirmId,
+          },
+          {
+            type: 2,
+            style: 4, // DANGER (red)
+            label: 'Cancel',
+            custom_id: cancelId,
+          },
+        ],
+      }],
+    }),
+  });
 }
 
 /**

--- a/close.js
+++ b/close.js
@@ -292,7 +292,7 @@ export async function handleCloseButton(req, res) {
     type: 6, // DEFERRED_UPDATE_MESSAGE
   });
 
-  const webhookUrl = `https://discord.com/api/v10/webhooks/${process.env.APP_ID}/${req.body.token}`;
+  const webhookUrl = `https://discord.com/api/v10/webhooks/${process.env.APP_ID}/${req.body.token}/messages/@original`;
 
   try {
     const results = [];
@@ -329,7 +329,7 @@ export async function handleCloseButton(req, res) {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          content: `Discord actions done, but wiki login failed:\n${results.join('\n')}\nError: ${e.message}`,
+          content: `**Proposal close partially failed.**\n\n${results.map(r => `• ${r}`).join('\n')}`,
           components: [],
         }),
       });

--- a/commands.js
+++ b/commands.js
@@ -231,7 +231,8 @@ const CLOSE_COMMAND = {
         { name: "Support (passed)", value: "support" },
         { name: "Oppose (failed)", value: "oppose" },
         { name: "Restructure (passed with restructure)", value: "restructure" },
-        { name: "Null (not enough votes / premature close)", value: "null" },
+        { name: "Null (not enough votes)", value: "null" },
+        { name: "Closed (invalid/premature close)", value: "closed" },
       ]
     },
     {

--- a/commands.js
+++ b/commands.js
@@ -214,6 +214,53 @@ const VERIFIED_MEMBERS_COMMAND = {
     }
   ]
 }
-const ALL_COMMANDS = [TEST_COMMAND, ARCHIVE_COMMAND, ALLOWED_CHANNELS_COMMAND, ALLOWED_ROLES_COMMAND, VERIFIED_MEMBERS_COMMAND];
+const CLOSE_COMMAND = {
+  name: "close",
+  description: "Close a meme proposal thread: count votes, archive, and update wiki pages",
+  type: 1,
+  integration_types: [0],
+  contexts: [0],
+  dm_permission: false,
+  options: [
+    {
+      name: "vote_result",
+      description: "The outcome of the proposal",
+      type: 3, // STRING
+      required: true,
+      choices: [
+        { name: "Support (passed)", value: "support" },
+        { name: "Oppose (failed)", value: "oppose" },
+        { name: "Restructure (passed with restructure)", value: "restructure" },
+        { name: "Null (not enough votes / premature close)", value: "null" },
+      ]
+    },
+    {
+      name: "summary",
+      description: "Short summary of the decision (e.g. 'We will create a meme page for X')",
+      type: 3, // STRING
+      required: true,
+    },
+    {
+      name: "support_count",
+      description: "Override the bot's detected support vote count",
+      type: 4, // INTEGER
+      required: false,
+    },
+    {
+      name: "oppose_count",
+      description: "Override the bot's detected oppose vote count",
+      type: 4, // INTEGER
+      required: false,
+    },
+    {
+      name: "restructure_count",
+      description: "Override the bot's detected total restructure vote count",
+      type: 4, // INTEGER
+      required: false,
+    },
+  ]
+};
+
+const ALL_COMMANDS = [TEST_COMMAND, ARCHIVE_COMMAND, ALLOWED_CHANNELS_COMMAND, ALLOWED_ROLES_COMMAND, VERIFIED_MEMBERS_COMMAND, CLOSE_COMMAND];
 
 InstallGlobalCommands(process.env.APP_ID, ALL_COMMANDS);

--- a/votecount.js
+++ b/votecount.js
@@ -7,7 +7,7 @@
  * - Multiple votes per user (latest non-crossed-out wins)
  */
 
-const VOTE_EMOJI_PATTERN = /<:(?:Voting[_ ]?(support|oppose|restructure|neutral)):(\d+)>/gi;
+const VOTE_EMOJI_PATTERN = /<:(?:Voting[_ ]?)?(support|oppose|restructure|neutral):(\d+)>/gi;
 const STRIKETHROUGH_PATTERN = /~~([\s\S]*?)~~/g;
 
 /**

--- a/votecount.js
+++ b/votecount.js
@@ -1,0 +1,236 @@
+/**
+ * Vote counting module for meme proposals.
+ *
+ * Works on Discord message objects (from the Discord API) and detects:
+ * - Custom emoji votes: <:Voting_support:ID>, <:Voting_oppose:ID>, etc.
+ * - Strikethrough crossouts: ~~...vote...~~
+ * - Multiple votes per user (latest non-crossed-out wins)
+ */
+
+const VOTE_EMOJI_PATTERN = /<:(?:Voting[_ ]?(support|oppose|restructure|neutral)):(\d+)>/gi;
+const STRIKETHROUGH_PATTERN = /~~([\s\S]*?)~~/g;
+
+/**
+ * Detect if a vote emoji in a message is crossed out via strikethrough.
+ * A vote is considered crossed out if the emoji appears inside ~~...~~.
+ * @param {string} content Message content
+ * @returns {{ voteType: string|null, crossedOut: boolean }}
+ */
+function detectVoteInContent(content) {
+  if (!content) return { voteType: null, crossedOut: false };
+
+  // First, find all vote emoji in the full content
+  const allVotes = [];
+  let match;
+  const fullPattern = new RegExp(VOTE_EMOJI_PATTERN.source, 'gi');
+  while ((match = fullPattern.exec(content)) !== null) {
+    allVotes.push({ type: match[1].toLowerCase(), index: match.index });
+  }
+
+  if (allVotes.length === 0) return { voteType: null, crossedOut: false };
+
+  // Find all strikethrough regions
+  const strikethroughRegions = [];
+  const stPattern = new RegExp(STRIKETHROUGH_PATTERN.source, 'g');
+  let stMatch;
+  while ((stMatch = stPattern.exec(content)) !== null) {
+    strikethroughRegions.push({ start: stMatch.index, end: stMatch.index + stMatch[0].length });
+  }
+
+  // For each vote, check if it's inside a strikethrough region
+  const votes = allVotes.map(vote => {
+    const inStrikethrough = strikethroughRegions.some(
+      region => vote.index >= region.start && vote.index < region.end
+    );
+    return { ...vote, crossedOut: inStrikethrough };
+  });
+
+  // Return the last non-crossed-out vote if any; otherwise the last crossed-out one
+  const nonCrossed = votes.filter(v => !v.crossedOut);
+  if (nonCrossed.length > 0) {
+    const last = nonCrossed[nonCrossed.length - 1];
+    return { voteType: last.type, crossedOut: false };
+  }
+
+  const last = votes[votes.length - 1];
+  return { voteType: last.type, crossedOut: true };
+}
+
+/**
+ * Count votes from an array of Discord messages.
+ * @param {Array<Object>} messages Discord message objects (chronological order, oldest first).
+ *   Each must have: { author: { id, username, bot? }, content }
+ * @returns {Object} { tally, voters, ambiguous, suggestedResult }
+ */
+export function countVotes(messages) {
+  // Map of userId -> { username, votes: [{ type, crossedOut, messageContent, timestamp }] }
+  const userVotes = new Map();
+
+  for (const msg of messages) {
+    if (msg.author.bot) continue;
+
+    const { voteType, crossedOut } = detectVoteInContent(msg.content);
+    if (!voteType) continue;
+
+    if (!userVotes.has(msg.author.id)) {
+      userVotes.set(msg.author.id, { username: msg.author.username, votes: [] });
+    }
+
+    userVotes.get(msg.author.id).votes.push({
+      type: voteType,
+      crossedOut,
+      messageContent: msg.content,
+      timestamp: msg.timestamp,
+    });
+  }
+
+  // Resolve each user's final vote
+  const finalVotes = new Map(); // userId -> { type, username, messageContent }
+  const ambiguous = []; // users with crossed-out votes but no clear replacement
+
+  for (const [userId, { username, votes }] of userVotes) {
+    const nonCrossed = votes.filter(v => !v.crossedOut);
+
+    if (nonCrossed.length > 0) {
+      // Use the latest non-crossed-out vote
+      const latest = nonCrossed[nonCrossed.length - 1];
+      finalVotes.set(userId, {
+        type: latest.type,
+        username,
+        messageContent: latest.messageContent,
+      });
+    } else {
+      // All votes are crossed out -- flag as ambiguous
+      ambiguous.push({
+        userId,
+        username,
+        lastVote: votes[votes.length - 1],
+      });
+    }
+  }
+
+  // Tally
+  const tally = { support: 0, oppose: 0, restructure: 0, neutral: 0 };
+  const voters = { support: [], oppose: [], restructure: [], neutral: [] };
+
+  for (const [userId, { type, username, messageContent }] of finalVotes) {
+    const normalizedType = type === 'neutral' ? 'neutral' : type;
+    tally[normalizedType] = (tally[normalizedType] || 0) + 1;
+    if (!voters[normalizedType]) voters[normalizedType] = [];
+    voters[normalizedType].push({ userId, username, messageContent });
+  }
+
+  const total = tally.support + tally.oppose + tally.restructure;
+
+  // Suggest result based on thresholds
+  let suggestedResult;
+  if (total < 7) {
+    suggestedResult = 'null';
+  } else if (tally.support / total >= 0.75) {
+    suggestedResult = 'support';
+  } else if (tally.restructure / total >= 0.75) {
+    suggestedResult = 'restructure';
+  } else {
+    suggestedResult = 'oppose';
+  }
+
+  return {
+    tally,
+    total,
+    voters,
+    ambiguous,
+    suggestedResult,
+  };
+}
+
+/**
+ * Evaluate the voting threshold rules.
+ * @param {number} support
+ * @param {number} oppose
+ * @param {number} restructure
+ * @returns {{ result: string, reason: string }}
+ */
+export function evaluateThreshold(support, oppose, restructure) {
+  const total = support + oppose + restructure;
+
+  if (total < 7) {
+    return { result: 'null', reason: `Not enough votes (${total}/7 minimum)` };
+  }
+
+  const supportPct = support / total;
+  const restructurePct = restructure / total;
+
+  if (supportPct >= 0.75) {
+    return { result: 'support', reason: `Support has ${(supportPct * 100).toFixed(1)}% (>= 75%)` };
+  }
+  if (restructurePct >= 0.75) {
+    return { result: 'restructure', reason: `Restructure has ${(restructurePct * 100).toFixed(1)}% (>= 75%)` };
+  }
+  return {
+    result: 'oppose',
+    reason: `No option reached 75%. Support: ${(supportPct * 100).toFixed(1)}%, Restructure: ${(restructurePct * 100).toFixed(1)}%`,
+  };
+}
+
+// Patterns that indicate a message is a tally/closing summary, not an actual vote
+const TALLY_INDICATORS = [
+  /Final Tally/i,
+  /\[PROPOSAL END\]/i,
+  /\[CLOSED\]/i,
+  /FINAL TALLY/,
+  /^\s*SUPPORTS?\s/i,
+  /Proposal (?:Rejected|Accepted|Passed)/i,
+  /Decision:/i,
+];
+
+/**
+ * Parse wikitext log (DiscordLog2 templates) into pseudo-message objects for testing.
+ * Skips `class=ping reply`, `class=date-separator` entries, and tally/closing messages.
+ * @param {string} wikitext Raw wikitext of a log page
+ * @returns {Array<Object>} Array of { author: { id, username, bot: false }, content }
+ */
+export function parseWikitextLog(wikitext) {
+  const messages = [];
+  // DiscordLog2 templates can span multiple lines, so use a greedy match up to }}
+  const templateRegex = /\{\{DiscordLog2\|([\s\S]*?)\}\}/g;
+  let match;
+
+  while ((match = templateRegex.exec(wikitext)) !== null) {
+    const params = match[1];
+
+    // Skip replies and date separators
+    if (params.includes('class=ping reply') || params.includes('class=date-separator') || params.includes('class=system-message')) {
+      continue;
+    }
+
+    // Extract |1= (username) and |2= (content)
+    const usernameMatch = params.match(/\|1=([^|]*?)(?:\||$)/);
+    const contentMatch = params.match(/\|2=([\s\S]*?)$/);
+
+    if (!usernameMatch) continue;
+
+    const username = usernameMatch[1].trim();
+    const content = contentMatch ? contentMatch[1].trim() : '';
+
+    // Skip tally/closing summary messages
+    if (TALLY_INDICATORS.some(pattern => pattern.test(content))) {
+      continue;
+    }
+
+    // Convert wikitext vote images back to Discord emoji format for the vote counter
+    const discordContent = content
+      .replace(/\[\[File:Voting-support\.svg\|20px\|link=\]\]/g, '<:Voting_support:0>')
+      .replace(/\[\[File:Voting-oppose\.svg\|20px\|link=\]\]/g, '<:Voting_oppose:0>')
+      .replace(/\[\[File:Voting-restructure\.svg\|20px\|link=\]\]/g, '<:Voting_restructure:0>')
+      .replace(/\[\[File:Voting-neutral\.svg\|20px\|link=\]\]/g, '<:Voting_neutral:0>')
+      .replace(/<s>/g, '~~').replace(/<\/s>/g, '~~');
+
+    messages.push({
+      author: { id: username, username, bot: false },
+      content: discordContent,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  return messages;
+}

--- a/wiki.js
+++ b/wiki.js
@@ -1,0 +1,181 @@
+import 'dotenv/config';
+
+const WIKI_API_URL = process.env.WIKI_API_URL || 'https://siivagunner.wiki/w/api.php';
+const WIKI_USERNAME = process.env.WIKI_USERNAME;
+const WIKI_PASSWORD = process.env.WIKI_PASSWORD;
+
+let cookies = '';
+let csrfToken = null;
+
+async function apiRequest(params, method = 'GET') {
+  params.format = 'json';
+  const url = new URL(WIKI_API_URL);
+
+  if (method === 'GET') {
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value);
+    }
+    const res = await fetch(url.toString(), {
+      headers: { Cookie: cookies },
+    });
+    updateCookies(res);
+    return res.json();
+  }
+
+  const body = new URLSearchParams(params);
+  const res = await fetch(url.toString(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Cookie: cookies,
+    },
+    body: body.toString(),
+  });
+  updateCookies(res);
+  return res.json();
+}
+
+function updateCookies(res) {
+  const setCookie = res.headers.getSetCookie?.() || [];
+  for (const c of setCookie) {
+    const name = c.split('=')[0];
+    const value = c.split(';')[0];
+    const existing = cookies.split('; ').filter(x => x && !x.startsWith(name + '='));
+    existing.push(value);
+    cookies = existing.join('; ');
+  }
+}
+
+export async function wikiLogin() {
+  if (!WIKI_USERNAME || !WIKI_PASSWORD) {
+    throw new Error('WIKI_USERNAME and WIKI_PASSWORD must be set in .env');
+  }
+
+  // Step 1: get login token
+  const tokenData = await apiRequest({
+    action: 'query',
+    meta: 'tokens',
+    type: 'login',
+  });
+  const loginToken = tokenData.query.tokens.logintoken;
+
+  // Step 2: log in
+  const loginData = await apiRequest({
+    action: 'login',
+    lgname: WIKI_USERNAME,
+    lgpassword: WIKI_PASSWORD,
+    lgtoken: loginToken,
+  }, 'POST');
+
+  if (loginData.login.result !== 'Success') {
+    throw new Error(`Wiki login failed: ${loginData.login.result} - ${loginData.login.reason || ''}`);
+  }
+
+  console.log(`Logged in to wiki as ${loginData.login.lgusername}`);
+  csrfToken = null;
+  return loginData;
+}
+
+async function getCsrfToken() {
+  if (csrfToken) return csrfToken;
+
+  const data = await apiRequest({
+    action: 'query',
+    meta: 'tokens',
+  });
+  csrfToken = data.query.tokens.csrftoken;
+  return csrfToken;
+}
+
+/**
+ * Read the wikitext source of a page.
+ * @param {string} title Page title
+ * @returns {string|null} Page wikitext, or null if the page doesn't exist
+ */
+export async function wikiReadPage(title) {
+  const data = await apiRequest({
+    action: 'query',
+    titles: title,
+    prop: 'revisions',
+    rvprop: 'content',
+    rvslots: 'main',
+  });
+
+  const pages = Object.values(data.query.pages);
+  const page = pages[0];
+  if (page.missing !== undefined) return null;
+  return page.revisions[0].slots.main['*'];
+}
+
+/**
+ * Edit (or create) a wiki page.
+ * @param {string} title Page title
+ * @param {string} content Full page wikitext (replaces existing)
+ * @param {string} summary Edit summary
+ * @returns {object} API response
+ */
+export async function wikiEditPage(title, content, summary) {
+  const token = await getCsrfToken();
+  const data = await apiRequest({
+    action: 'edit',
+    title,
+    text: content,
+    summary,
+    token,
+    bot: '1',
+  }, 'POST');
+
+  if (data.error) {
+    // Token may have expired; refresh and retry once
+    if (data.error.code === 'badtoken') {
+      csrfToken = null;
+      const freshToken = await getCsrfToken();
+      return apiRequest({
+        action: 'edit',
+        title,
+        text: content,
+        summary,
+        token: freshToken,
+        bot: '1',
+      }, 'POST');
+    }
+    throw new Error(`Wiki edit failed: ${data.error.code} - ${data.error.info}`);
+  }
+  return data;
+}
+
+/**
+ * Append text to the end of a wiki page (or create it).
+ * @param {string} title Page title
+ * @param {string} text Text to append
+ * @param {string} summary Edit summary
+ * @returns {object} API response
+ */
+export async function wikiAppendToPage(title, text, summary) {
+  const token = await getCsrfToken();
+  const data = await apiRequest({
+    action: 'edit',
+    title,
+    appendtext: text,
+    summary,
+    token,
+    bot: '1',
+  }, 'POST');
+
+  if (data.error) {
+    if (data.error.code === 'badtoken') {
+      csrfToken = null;
+      const freshToken = await getCsrfToken();
+      return apiRequest({
+        action: 'edit',
+        title,
+        appendtext: text,
+        summary,
+        token: freshToken,
+        bot: '1',
+      }, 'POST');
+    }
+    throw new Error(`Wiki append failed: ${data.error.code} - ${data.error.info}`);
+  }
+  return data;
+}

--- a/wiki.js
+++ b/wiki.js
@@ -6,6 +6,7 @@ const WIKI_PASSWORD = process.env.WIKI_PASSWORD;
 
 let cookies = '';
 let csrfToken = null;
+let loggedIn = false;
 
 async function apiRequest(params, method = 'GET') {
   params.format = 'json';
@@ -47,6 +48,8 @@ function updateCookies(res) {
 }
 
 export async function wikiLogin() {
+  if (loggedIn) return;
+
   if (!WIKI_USERNAME || !WIKI_PASSWORD) {
     throw new Error('WIKI_USERNAME and WIKI_PASSWORD must be set in .env');
   }
@@ -72,6 +75,7 @@ export async function wikiLogin() {
   }
 
   console.log(`Logged in to wiki as ${loginData.login.lgusername}`);
+  loggedIn = true;
   csrfToken = null;
   return loginData;
 }

--- a/wiki.js
+++ b/wiki.js
@@ -12,27 +12,34 @@ async function apiRequest(params, method = 'GET') {
   params.format = 'json';
   const url = new URL(WIKI_API_URL);
 
+  let res;
   if (method === 'GET') {
     for (const [key, value] of Object.entries(params)) {
       url.searchParams.set(key, value);
     }
-    const res = await fetch(url.toString(), {
+    res = await fetch(url.toString(), {
       headers: { Cookie: cookies },
     });
-    updateCookies(res);
-    return res.json();
+  } else {
+    const form = new FormData();
+    for (const [key, value] of Object.entries(params)) {
+      form.append(key, value);
+    }
+    res = await fetch(url.toString(), {
+      method: 'POST',
+      headers: { Cookie: cookies },
+      body: form,
+    });
   }
 
-  const body = new URLSearchParams(params);
-  const res = await fetch(url.toString(), {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      Cookie: cookies,
-    },
-    body: body.toString(),
-  });
   updateCookies(res);
+
+  const contentType = res.headers.get('content-type') || '';
+  if (!contentType.includes('json')) {
+    const text = await res.text();
+    throw new Error(`Wiki API returned non-JSON (HTTP ${res.status}): ${text.slice(0, 200)}`);
+  }
+
   return res.json();
 }
 

--- a/wikiformat.js
+++ b/wikiformat.js
@@ -44,11 +44,13 @@ export function archiveAnchor(day, subject) {
 export function proposalsPageRow({ subject, day, proposer, startDate, endDate, voteResult }) {
   const anchor = archiveAnchor(day, subject);
 
-  const resultCell = voteResult === 'null'
-    ? 'Null'
+  const isNull = voteResult === 'null' || voteResult === 'closed';
+
+  const resultCell = isNull
+    ? (voteResult === 'closed' ? 'Closed' : 'Null')
     : `{{Icon|Voting-${voteResult}.svg}} [[/Archive#${anchor}|Summary]]`;
 
-  const logLink = voteResult === 'null'
+  const logLink = isNull
     ? subject
     : `[[/Log/${toOrdinal(day)}: ${subject}|${subject}]]`;
 
@@ -78,8 +80,9 @@ export function archiveEntry({ subject, day, summary, voteResult, supportCount, 
   const heading = `==== ${toOrdinal(day)}: ${subject} ====`;
 
   let bullet;
-  if (voteResult === 'null') {
-    bullet = `*Not enough votes (${total}/7) - proposal nulled.`;
+  if (voteResult === 'null' || voteResult === 'closed') {
+    const reason = voteResult === 'closed' ? 'proposal closed.' : 'proposal nulled.';
+    bullet = `*Not enough votes (${total}/7) - ${reason}`;
   } else {
     bullet = `*${summary} {{VoteSummary|${supportCount}|${opposeCount}|${restructureCount}}}`;
   }

--- a/wikiformat.js
+++ b/wikiformat.js
@@ -97,7 +97,12 @@ export function archiveEntry({ subject, day, summary, voteResult, supportCount, 
  */
 export function todoRow({ subject, day, summary }) {
   const anchor = archiveAnchor(day, subject);
-  return `| [[SiIvaGunner Wiki:Meme discussion/Archive#${anchor}|${summary}]] || ''To be filled in by a wiki editor'' || 0%`;
+  return [
+    `|[[SiIvaGunner_Wiki:Meme_discussion/Archive#${anchor}|${summary}]]`,
+    `|`,
+    `# ''To be filled in by a wiki editor''`,
+    `|0%`,
+  ].join('\n');
 }
 
 /**
@@ -111,5 +116,11 @@ export function todoRow({ subject, day, summary }) {
  */
 export function progressRow({ subject, day, summary, currentDate }) {
   const anchor = archiveAnchor(day, subject);
-  return `| [[SiIvaGunner Wiki:Meme discussion/Archive#${anchor}|${toOrdinal(day)}]] || ${summary} || '''Not done''' || ${currentDate} ||`;
+  return [
+    `| [[../Archive#${anchor}|${currentDate}]]`,
+    `| ${summary}`,
+    `| '''Not done'''`,
+    `| ${currentDate}`,
+    `|`,
+  ].join('\n');
 }

--- a/wikiformat.js
+++ b/wikiformat.js
@@ -1,0 +1,129 @@
+/**
+ * Convert a day-of-month number to its ordinal string (1st, 2nd, 3rd, 4th, ..., 31st).
+ * @param {number} day
+ * @returns {string}
+ */
+export function toOrdinal(day) {
+  const suffixes = { 1: 'st', 2: 'nd', 3: 'rd' };
+  const teens = day >= 11 && day <= 13;
+  const suffix = teens ? 'th' : (suffixes[day % 10] || 'th');
+  return `${day}${suffix}`;
+}
+
+/**
+ * Build the log page title from the proposal's start date and subject.
+ * @param {number} day Day of month the proposal started
+ * @param {string} subject Proposal subject (e.g. "Meatball Parade")
+ * @returns {string} Full page title like "SiIvaGunner Wiki:Meme discussion/Log/22nd: Meatball Parade"
+ */
+export function logPageTitle(day, subject) {
+  return `SiIvaGunner Wiki:Meme discussion/Log/${toOrdinal(day)}: ${subject}`;
+}
+
+/**
+ * Build the archive anchor from the proposal's start date and subject.
+ * @param {number} day
+ * @param {string} subject
+ * @returns {string} Anchor like "22nd: Meatball Parade"
+ */
+export function archiveAnchor(day, subject) {
+  return `${toOrdinal(day)}: ${subject}`;
+}
+
+/**
+ * Format a percentage to one decimal place.
+ * @param {number} count
+ * @param {number} total
+ * @returns {string}
+ */
+function pct(count, total) {
+  if (total === 0) return '0%';
+  return `${((count / total) * 100).toFixed(1)}%`;
+}
+
+/**
+ * Generate a proposals-page row for the Ended table.
+ * @param {object} opts
+ * @param {string} opts.subject
+ * @param {number} opts.day
+ * @param {string} opts.proposer Wiki username
+ * @param {string} opts.startDate e.g. "April 14, 2025"
+ * @param {string} opts.endDate
+ * @param {string} opts.voteResult "support"|"oppose"|"restructure"|"null"
+ * @returns {string} Wikitext table row
+ */
+export function proposalsPageRow({ subject, day, proposer, startDate, endDate, voteResult }) {
+  const anchor = archiveAnchor(day, subject);
+  const logTitle = logPageTitle(day, subject);
+
+  if (voteResult === 'null') {
+    return `| ${subject} || [[User:${proposer}|${proposer}]] || ${startDate} || ${endDate} || Null`;
+  }
+
+  const emojiFile = voteResult === 'support' ? 'Voting-support.svg'
+    : voteResult === 'oppose' ? 'Voting-oppose.svg'
+    : 'Voting-restructure.svg';
+
+  return `| [[${logTitle}|${subject}]] || [[User:${proposer}|${proposer}]] || ${startDate} || ${endDate} || [[File:${emojiFile}|20px]] [[SiIvaGunner Wiki:Meme discussion/Archive#${anchor}|Summary]]`;
+}
+
+/**
+ * Generate an archive page entry (heading + bullet summary).
+ * @param {object} opts
+ * @param {string} opts.subject
+ * @param {number} opts.day
+ * @param {string} opts.summary Human-written summary text
+ * @param {string} opts.voteResult
+ * @param {number} opts.supportCount
+ * @param {number} opts.opposeCount
+ * @param {number} opts.restructureCount
+ * @returns {string} Wikitext for the archive entry
+ */
+export function archiveEntry({ subject, day, summary, voteResult, supportCount, opposeCount, restructureCount }) {
+  const total = supportCount + opposeCount + restructureCount;
+  const heading = `#### ${toOrdinal(day)}: **${subject}**`;
+
+  let tallySummary;
+  if (voteResult === 'null') {
+    const parts = [];
+    if (supportCount > 0) parts.push(`support: ${supportCount} (${pct(supportCount, total)})`);
+    if (restructureCount > 0) parts.push(`restructure ${restructureCount} (${pct(restructureCount, total)})`);
+    if (opposeCount > 0) parts.push(`oppose ${opposeCount} (${pct(opposeCount, total)})`);
+    tallySummary = `* Not enough votes were cast for a decision to be made. (${total} total: ${parts.join(', ')})`;
+  } else {
+    const parts = [];
+    if (supportCount > 0) parts.push(`support: ${supportCount} (${pct(supportCount, total)})`);
+    if (restructureCount > 0) parts.push(`restructure ${restructureCount} (${pct(restructureCount, total)})`);
+    if (opposeCount > 0) parts.push(`oppose ${opposeCount} (${pct(opposeCount, total)})`);
+    tallySummary = `* ${summary} (${total} total: ${parts.join(', ')})`;
+  }
+
+  return `${heading}\n\n${tallySummary}`;
+}
+
+/**
+ * Generate a scaffold to-do list row.
+ * @param {object} opts
+ * @param {string} opts.subject
+ * @param {number} opts.day
+ * @param {string} opts.summary
+ * @returns {string}
+ */
+export function todoRow({ subject, day, summary }) {
+  const anchor = archiveAnchor(day, subject);
+  return `| [[SiIvaGunner Wiki:Meme discussion/Archive#${anchor}|${summary}]] || ''To be filled in by a wiki editor'' || 0%`;
+}
+
+/**
+ * Generate a scaffold progress page row.
+ * @param {object} opts
+ * @param {string} opts.subject
+ * @param {number} opts.day
+ * @param {string} opts.summary
+ * @param {string} opts.currentDate e.g. "March 1, 2026"
+ * @returns {string}
+ */
+export function progressRow({ subject, day, summary, currentDate }) {
+  const anchor = archiveAnchor(day, subject);
+  return `| [[SiIvaGunner Wiki:Meme discussion/Archive#${anchor}|${toOrdinal(day)}]] || ${summary} || '''Not done''' || ${currentDate} ||`;
+}

--- a/wikiformat.js
+++ b/wikiformat.js
@@ -31,17 +31,6 @@ export function archiveAnchor(day, subject) {
 }
 
 /**
- * Format a percentage to one decimal place.
- * @param {number} count
- * @param {number} total
- * @returns {string}
- */
-function pct(count, total) {
-  if (total === 0) return '0%';
-  return `${((count / total) * 100).toFixed(1)}%`;
-}
-
-/**
  * Generate a proposals-page row for the Ended table.
  * @param {object} opts
  * @param {string} opts.subject
@@ -54,17 +43,22 @@ function pct(count, total) {
  */
 export function proposalsPageRow({ subject, day, proposer, startDate, endDate, voteResult }) {
   const anchor = archiveAnchor(day, subject);
-  const logTitle = logPageTitle(day, subject);
 
-  if (voteResult === 'null') {
-    return `| ${subject} || [[User:${proposer}|${proposer}]] || ${startDate} || ${endDate} || Null`;
-  }
+  const resultCell = voteResult === 'null'
+    ? 'Null'
+    : `{{Icon|Voting-${voteResult}.svg}} [[/Archive#${anchor}|Summary]]`;
 
-  const emojiFile = voteResult === 'support' ? 'Voting-support.svg'
-    : voteResult === 'oppose' ? 'Voting-oppose.svg'
-    : 'Voting-restructure.svg';
+  const logLink = voteResult === 'null'
+    ? subject
+    : `[[/Log/${toOrdinal(day)}: ${subject}|${subject}]]`;
 
-  return `| [[${logTitle}|${subject}]] || [[User:${proposer}|${proposer}]] || ${startDate} || ${endDate} || [[File:${emojiFile}|20px]] [[SiIvaGunner Wiki:Meme discussion/Archive#${anchor}|Summary]]`;
+  return [
+    `|${logLink}`,
+    `|[[User:${proposer}|${proposer}]]`,
+    `|${startDate}`,
+    `|${endDate}`,
+    `|${resultCell}`,
+  ].join('\n');
 }
 
 /**
@@ -81,24 +75,16 @@ export function proposalsPageRow({ subject, day, proposer, startDate, endDate, v
  */
 export function archiveEntry({ subject, day, summary, voteResult, supportCount, opposeCount, restructureCount }) {
   const total = supportCount + opposeCount + restructureCount;
-  const heading = `#### ${toOrdinal(day)}: **${subject}**`;
+  const heading = `==== ${toOrdinal(day)}: ${subject} ====`;
 
-  let tallySummary;
+  let bullet;
   if (voteResult === 'null') {
-    const parts = [];
-    if (supportCount > 0) parts.push(`support: ${supportCount} (${pct(supportCount, total)})`);
-    if (restructureCount > 0) parts.push(`restructure ${restructureCount} (${pct(restructureCount, total)})`);
-    if (opposeCount > 0) parts.push(`oppose ${opposeCount} (${pct(opposeCount, total)})`);
-    tallySummary = `* Not enough votes were cast for a decision to be made. (${total} total: ${parts.join(', ')})`;
+    bullet = `*Not enough votes (${total}/7) - proposal nulled.`;
   } else {
-    const parts = [];
-    if (supportCount > 0) parts.push(`support: ${supportCount} (${pct(supportCount, total)})`);
-    if (restructureCount > 0) parts.push(`restructure ${restructureCount} (${pct(restructureCount, total)})`);
-    if (opposeCount > 0) parts.push(`oppose ${opposeCount} (${pct(opposeCount, total)})`);
-    tallySummary = `* ${summary} (${total} total: ${parts.join(', ')})`;
+    bullet = `*${summary} {{VoteSummary|${supportCount}|${opposeCount}|${restructureCount}}}`;
   }
 
-  return `${heading}\n\n${tallySummary}`;
+  return `${heading}\n${bullet}`;
 }
 
 /**


### PR DESCRIPTION
Resolves #38 (note instead of `/summarize`, I settled on implementing `/close` instead).

## Summary
Adds **`/close`**: a moderator-only workflow to close meme proposal forum threads with:
- vote counting
- Discord thread housekeeping (renames Discord threads, tags the forum threads, archives the thread, and locks the thread)
- MediaWiki edits (edits log page, proposals table row, archive entry, to-do/progress scaffolding). 

This PR also includes Jest coverage for vote counting, thresholds, and wikitext formatting, and expands README (env vars, setup, wiki markers, permissions).

## Motivation

Manually updating 5+ wiki pages and editing the thread for every proposal is slow and error-prone. This automates the mechanical steps behind a preview + confirm/cancel interaction.

## Behavior

- Slash command `close` (see [commands.js](./commands.js)): options `vote_result` (support / oppose / restructure / null / closed), `summary`, optional numeric overrides for vote counts.
- Gating: Only members with an allowed role can run `/close` (same pattern as other admin commands in [app.js](./app.js)).
- Vote logic ([votecount.js](./votecount.js)): detects voting custom emojis, respects `~~strikethrough~~` crossouts, last non–crossed-out vote per user wins; evaluates 75% / minimum 7 voters threshold where applicable.
- UX: Immediate deferral / follow-up via interaction webhooks; Confirm and Cancel buttons with server-side pending state; errors surfaced in follow-up messages.
- Discord side ([close.js](./close.js)): maps outcome to forum tag and `[CLOSED]` / `[NULL]` thread name prefix; archives and locks the thread when appropriate.
- Wiki side ([wiki.js](./wiki.js), [wikiformat.js](./wikiformat.js)): bot-password session, page read/edit/append; inserts content at documented HTML comment markers (see README).

Made with Cursor.
