### PR TITLE
Simplify /verified_members list output (fixes #36)

### DIFF
--- a/app.js
+++ b/app.js
@@ -480,9 +480,10 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async fun
             message = "No members have a wiki account.";
           } else {
             console.log('Formatting members list...');
-            const membersList = members.map(member =>
-              `${member.displayName} (${member.memberId}) - Wiki Account: ${member.wikiAccount}`
-            ).join('\n');
+            const membersList = [
+              'Key: Discord username - Wiki account',
+              ...members.map(member => `${member.displayName} - ${member.wikiAccount}`),
+            ].join('\n');
 
             // Create a buffer from the content
             const buffer = Buffer.from(membersList, 'utf8');

--- a/archive.js
+++ b/archive.js
@@ -226,18 +226,32 @@ export function setAllowedRoles(roles) {
  * @returns An array of objects containing member IDs and wiki accounts
  */
 export function getVerifiedMembers() {
-    return db.prepare('SELECT member_id AS memberId, wiki_account AS wikiAccount, display_name AS displayName FROM verified_members').all();
+    return db.prepare(
+        `SELECT member_id AS memberId, wiki_account AS wikiAccount, display_name AS displayName
+         FROM verified_members
+         ORDER BY COALESCE(display_name, '') COLLATE NOCASE, member_id`
+    ).all();
 }
 
 /**
  * Set the members that are verified
  * @param {Array} members An array of objects containing member IDs and wiki accounts
  */
+function sortVerifiedMembersForStorage(members) {
+    return [...members].sort((a, b) => {
+        const an = (a.displayName || '').toLowerCase();
+        const bn = (b.displayName || '').toLowerCase();
+        if (an !== bn) return an.localeCompare(bn);
+        return (a.memberId || '').localeCompare(b.memberId || '');
+    });
+}
+
 export function setVerifiedMembers(members) {
+    const ordered = sortVerifiedMembersForStorage(members);
     db.transaction(() => {
         db.prepare('DELETE FROM verified_members').run();
         const insert = db.prepare('INSERT INTO verified_members (member_id, wiki_account, display_name) VALUES (?, ?, ?)');
-        for (const m of members) insert.run(m.memberId, m.wikiAccount, m.displayName || null);
+        for (const m of ordered) insert.run(m.memberId, m.wikiAccount, m.displayName || null);
     })();
 }
 


### PR DESCRIPTION
Closes #36.

- List attachment: header line plus `displayName - wikiAccount` per row; omit Discord IDs.
- `getVerifiedMembers`: `ORDER BY` display name (case-insensitive) then member id.
- `setVerifiedMembers`: sort before insert so add/remove persist stable order.

Made with [Cursor](https://cursor.com)