### PR TITLE
feat(archive): DiscordLog2 id and replyto for reply anchors (#24)

### DIFF
--- a/__tests__/archive.test.js
+++ b/__tests__/archive.test.js
@@ -376,4 +376,50 @@ describe('Message Formatting', () => {
       );
     });
   });
+
+  describe('Message anchors (issue #24)', () => {
+    test('normal row with Discord message id gets id= fragment param', () => {
+      const message = {
+        id: '1111111111111111111',
+        content: 'Hello',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z'
+      };
+      expect(formatMessageToWikitext(message, authors)).toBe(
+        '{{DiscordLog2|id=message_1111111111111111111|t= 21:36|1=Ironwestie|2=Hello}}'
+      );
+    });
+
+    test('ping-reply preview row uses replyto= not id=', () => {
+      const message = {
+        id: '2222222222222222222',
+        content: 'Quoted parent',
+        author: { id: '456' },
+        timestamp: '2025-03-21T21:35:27.000Z'
+      };
+      expect(formatMessageToWikitext(message, authors, true)).toBe(
+        '{{DiscordLog2|replyto=message_2222222222222222222|class=ping reply|1=TestUser|2=Quoted parent}}'
+      );
+    });
+
+    test('reply context links preview to parent id and anchors the reply', () => {
+      const message = {
+        id: '3333333333333333333',
+        type: 19,
+        content: 'Reply body',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z',
+        referenced_message: {
+          id: '4444444444444444444',
+          content: 'Parent',
+          author: { id: '456' },
+          timestamp: '2025-03-21T21:35:27.000Z'
+        }
+      };
+      expect(formatMessageWithContext(message, authors)).toBe(
+        '{{DiscordLog2|replyto=message_4444444444444444444|class=ping reply|1=TestUser|2=Parent}}\n' +
+        '{{DiscordLog2|id=message_3333333333333333333|t= 21:36|1=Ironwestie|2=Reply body}}'
+      );
+    });
+  });
 });

--- a/archive.js
+++ b/archive.js
@@ -65,20 +65,31 @@ db.exec(`
 })();
 
 /**
-   * Format a message to wikitext
-   * @param {*} message The message to format. Format:
-   * @param {Array} authors The array of verified members
-   * @param {boolean} reply Whether the message is a reply
-   * @param {boolean} forwarded Whether the message is a forwarded message
-   * @param {boolean} simpleDate Whether to use the simple date format (21:56) or the full date format (Fri, 21 Mar 2025 21:56)
-   * @returns A string of the message formatted as wikitext
-   */
+ * Format a message to wikitext
+ * @param {*} message The message to format (Discord API shape). When `message.id` is set, adds
+ *   `id=message_<id>` on normal rows or `replyto=message_<id>` on ping-reply preview rows for wiki anchors.
+ * @param {Array} authors The array of verified members
+ * @param {boolean} reply Whether the message is a reply
+ * @param {boolean} forwarded Whether the message is a forwarded message
+ * @param {boolean} simpleDate Whether to use the simple date format (21:56) or the full date format (Fri, 21 Mar 2025 21:56)
+ * @returns A string of the message formatted as wikitext
+ */
 export function formatMessageToWikitext (message, authors, reply = false, forwarded = false, simpleDate = true) {
     // Format:
     // {{DiscordLog|t=timestamp|authorLink|content}}
+    // id=/replyto= are consumed by Template:DiscordLog2 for anchors and reply links (#message_<snowflake>).
     const templatePrefix = `{{DiscordLog2`
     const parts = [];
     parts.push(templatePrefix);
+
+    if (message.id) {
+      const anchor = `message_${message.id}`;
+      if (reply) {
+        parts.push(`replyto=${anchor}`);
+      } else {
+        parts.push(`id=${anchor}`);
+      }
+    }
 
     const timestamp = new Date(message.timestamp).toUTCString();
     const timestampFormatted = simpleDate ? timestamp.slice(16, 22) : timestamp;


### PR DESCRIPTION
Resolves #24 .
## Summary
- Emit `id=message_<snowflake>` on canonical `DiscordLog2` rows and `replyto=message_<snowflake>` on ping-reply preview rows when `message.id` is present, so the wiki template can anchor and link (`#message_…`).
- Omit both when `message.id` is missing (tests and malformed payloads unchanged).
- Add regression tests for the new parameters.

## Test plan
- [x] `npm test`
- [x] Paste a fresh `/archive` export on the wiki and confirm `Template:DiscordLog2` uses `id` / `replyto` as intended (wiki template/CSS is separate).

Made with [Cursor](https://cursor.com)