### PR TITLE
Issue 62 ignore bots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ allowed_roles.json
 verified_members.json
 verified_members_roles.json
 verified_roles.json
+.vscode/*

--- a/__tests__/archive.test.js
+++ b/__tests__/archive.test.js
@@ -227,6 +227,46 @@ describe('Message Formatting', () => {
       );
     });
 
+    test('Reply to bot message omits referenced bot preview', () => {
+      const message = {
+        type: 19,
+        content: 'Human reply after bot',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z',
+        referenced_message: {
+          content: 'Bot stock reply that must not appear in archive',
+          author: { id: '999', username: 'ArchiveBot', bot: true },
+          timestamp: '2025-03-21T21:35:27.000Z'
+        }
+      };
+      expect(formatMessageWithContext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=Human reply after bot}}'
+      );
+    });
+
+    test('Reply to forwarded message when referenced author is a bot omits preview', () => {
+      const message = {
+        type: 19,
+        content: 'Reply after bot forwarded wrapper',
+        author: { id: '123' },
+        timestamp: '2025-03-21T21:36:27.000Z',
+        referenced_message: {
+          content: 'Forwarded content',
+          author: { id: '999', username: 'SomeBot', bot: true },
+          timestamp: '2025-03-21T21:35:27.000Z',
+          message_snapshots: [{
+            message: {
+              content: 'Original forwarded content',
+              timestamp: '2025-03-21T21:35:27.000Z'
+            }
+          }]
+        }
+      };
+      expect(formatMessageWithContext(message, authors)).toBe(
+        '{{DiscordLog2|t= 21:36|1=Ironwestie|2=Reply after bot forwarded wrapper}}'
+      );
+    });
+
     test('Reply to forwarded message', () => {
       const message = {
         type: 19,

--- a/app.js
+++ b/app.js
@@ -17,7 +17,8 @@ import {
   getVerifiedRoles,
   setVerifiedRoles,
   addRoleToMember,
-  getMemberInfo
+  getMemberInfo,
+  isBotAuthoredMessage
 } from './archive.js';
 import { handleCloseCommand, handleCloseButton } from './close.js';
 
@@ -177,7 +178,7 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async fun
         const authors = await getVerifiedMembers();
         // Filter out bot messages and reverse the order
         const messagesReversed = messages
-          .filter(message => !message.author.bot) // Remove bot messages
+          .filter(message => !isBotAuthoredMessage(message))
           .reverse();
         const fileContent = `<templatestyles src="Template:DiscordLog/styles.css"/>\n` +
           formatMessagesWithContext(messagesReversed, authors);
@@ -204,6 +205,7 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async fun
 
         // If there are unverified users, send a message to the channel
         const unverifiedUsers = messages.filter((message, index, self) =>
+          !isBotAuthoredMessage(message) &&
           !authors.find(author => author.memberId === message.author.id) &&
           index === self.findIndex(m => m.author.id === message.author.id)
         );

--- a/archive.js
+++ b/archive.js
@@ -333,6 +333,14 @@ export async function getMemberInfo(guildId, memberId) {
 }
 
 /**
+ * @param {Object} message Discord API message object
+ * @returns {boolean} True when message.author.bot is strictly true
+ */
+export function isBotAuthoredMessage(message) {
+  return message?.author?.bot === true;
+}
+
+/**
  * Format an array of messages with their context (replies and forwards)
  * @param {Array} messages The array of messages to format
  * @param {Array} authors Array of verified members
@@ -377,6 +385,9 @@ export function formatMessageWithContext(message, authors) {
     // Handle reply message
     const referencedMessage = message.referenced_message;
     if (referencedMessage) {
+      if (isBotAuthoredMessage(referencedMessage)) {
+        return formatMessageToWikitext(message, authors);
+      }
       if (referencedMessage.message_snapshots && referencedMessage.message_snapshots.length > 0) {
         // Handle a reply to a forwarded message
         const messageSnapshot = referencedMessage.message_snapshots[0].message;

--- a/docs/commands-and-setup.md
+++ b/docs/commands-and-setup.md
@@ -219,6 +219,13 @@ Set up [log rotation](https://en.wikipedia.org/wiki/Log_rotation) so log files a
    - SSL/TLS errors - Verify certificate validity and Cloudflare settings
    - Permission errors - Verify bot has correct Discord permissions
    - Database errors - Check file permissions and disk space
+   - `better-sqlite3` / `ERR_DLOPEN_FAILED` / "compiled against a different Node.js version" (e.g. `NODE_MODULE_VERSION 115` vs `127`): the native addon was built for a different Node than the one running the bot (common if `npm install` or `npm rebuild` used another `node` on `PATH`, while PM2 uses `/usr/bin/node`). Fix on the Pi: rebuild with the same Node PM2 uses, then restart:
+     ```bash
+     cd /path/to/DiscordWikitextArchive
+     PATH=/usr/bin:/bin npm_config_build_from_source=true npm rebuild better-sqlite3
+     pm2 restart discord-bot
+     ```
+     Use `node -v` under that same `PATH` and compare to `pm2 describe discord-bot` (Node.js version). On slow devices, `--build-from-source` can take several minutes.
 
 ### Backup and Recovery
 


### PR DESCRIPTION
Resolves #62 .

## Changes
- Add `isBotAuthoredMessage` fn to `archive.js` to ignore message from `author`s tagged as `bot: true` (see Discord's documentation on the [User](https://docs.discord.com/developers/resources/user#user-object) resource)
- Added `.vscode` directory to `.gitignore`; I experienced an issue with differing Node versions in my local set up and had to change some configs. This is documented in [docs/commands-and-setup.md](https://github.com/engineereng/DiscordWikitextArchive/compare/main...issue-62-ignore-bots#diff-10a2bbbed57758bef09e63de81f75fb95ea647a7bbcd3c11f7aeab0687c392c4)

## Tests
- Two new tests added for bots